### PR TITLE
外部施設関連の実装を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 
 # secrets
 .clasp.json
+packages/backend/src/source/places/*.ts
+!packages/backend/src/source/places/base.ts

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ yarn-error.log*
 
 # secrets
 .clasp.json
-packages/backend/src/source/places/*.ts
-!packages/backend/src/source/places/base.ts
+packages/backend/src/source/places/secrets/*.ts
+packages/backend/src/source/places/secrets/*.js

--- a/packages/backend/src/core/research.ts
+++ b/packages/backend/src/core/research.ts
@@ -19,7 +19,7 @@ export function researchManager() {
     // 新規でセッションを開始（'ready' -> 'opening'）
     // if(今日の日付＞セッションの開始日＆ステータス＝'ready')
     if (
-      dayjs().diff(session.startDate, 'day') >= 0 &&
+      dayjs().isAfter(session.startDate, 'day') &&
       session.status === 'ready'
     ) {
       startSession(session.id);
@@ -29,7 +29,7 @@ export function researchManager() {
     // if(今日の日付＞リマインド予定日＆ステータス＝'opening')
     else if (
       session.remindDate &&
-      dayjs().diff(session.remindDate, 'day') === 0 &&
+      dayjs().isSame(session.remindDate, 'day') &&
       session.status === 'opening'
     ) {
       sendRemind(session.id);
@@ -37,7 +37,7 @@ export function researchManager() {
     // 管理者へ候補日の案内（'opening' -> 'judge'）
     // if(本日の日付＞セッションの終了日＆ステータス＝'opening')
     else if (
-      dayjs().diff(session.endDate, 'day') >= 0 &&
+      dayjs().isAfter(session.endDate, 'day') &&
       session.status === 'opening'
     ) {
       sendJudgeCandidate(session.id);
@@ -58,5 +58,8 @@ if (import.meta.vitest) {
     const today = dayjs('2024-01-03');
     expect(today.diff('2024-01-05', 'day')).toBe(-2);
     expect(today.diff('2024-01-01', 'day')).toBe(2);
+    expect(today.isAfter('2024-01-01', 'day')).toBe(true);
   });
+
+  // TODO: テストを作成
 }

--- a/packages/backend/src/core/research.ts
+++ b/packages/backend/src/core/research.ts
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import { updateSession } from 'backend/source/spreadsheet/session';
 import { sessionChecker } from './research/checker';
 import { sendJudgeCandidate } from './research/decideHoldingDate';
-import { sendRemindMail } from './research/remindResearch';
+import { sendRemind } from './research/remindResearch';
 import { startSession } from './research/startResearch';
 
 /**
@@ -32,7 +32,7 @@ export function researchManager() {
       dayjs().diff(session.remindDate, 'day') === 0 &&
       session.status === 'opening'
     ) {
-      sendRemindMail(session.id);
+      sendRemind(session.id);
     }
     // 管理者へ候補日の案内（'opening' -> 'judge'）
     // if(本日の日付＞セッションの終了日＆ステータス＝'opening')

--- a/packages/backend/src/core/research/decideHoldingDate.ts
+++ b/packages/backend/src/core/research/decideHoldingDate.ts
@@ -1,23 +1,27 @@
 /**
  * 調査結果を踏まえて開催日を決定する
  */
-import { SessionID } from '@research-vacant/common';
+import { SessionID, values } from '@research-vacant/common';
+import { sendApproveMail } from 'backend/source/mail';
+import { getMembers } from 'backend/source/spreadsheet/members';
 
 /**
  * 調査結果をもとにした候補日の承認を管理者に問い合わせる
  */
 export function sendJudgeCandidate(sessionId: SessionID) {
-  const candidateDates = getCandidate();
+  const fullMembers=  values(getMembers())
+  const managerMembers = fullMembers.filter(
+    (member) => member.roles?.manager
+  );
 
-  // 承認もWebapp上でできるようにする（期日終了後に管理者がアクセスしたときに承認画面が開くようにする？）
-}
+  // 管理者が登録されていない場合は一番上のメンバーを管理者と仮定する
+  if (managerMembers.length === 0) {
+    managerMembers.push(fullMembers[0])
+  }
 
-/**
- * シートの中から候補日を確定させる
- */
-function getCandidate() {
-  // 外部施設の場合は施設の予約状況を問い合わせる
-  // 問い合わせ結果とメンバーの空き日程をもとに候補日を選定する
+  managerMembers.forEach(m => {
+    sendApproveMail(sessionId, m)
+  })
 }
 
 /**

--- a/packages/backend/src/core/research/decideHoldingDate.ts
+++ b/packages/backend/src/core/research/decideHoldingDate.ts
@@ -9,19 +9,17 @@ import { getMembers } from 'backend/source/spreadsheet/members';
  * 調査結果をもとにした候補日の承認を管理者に問い合わせる
  */
 export function sendJudgeCandidate(sessionId: SessionID) {
-  const fullMembers=  values(getMembers())
-  const managerMembers = fullMembers.filter(
-    (member) => member.roles?.manager
-  );
+  const fullMembers = values(getMembers());
+  const managerMembers = fullMembers.filter((member) => member.roles?.manager);
 
   // 管理者が登録されていない場合は一番上のメンバーを管理者と仮定する
   if (managerMembers.length === 0) {
-    managerMembers.push(fullMembers[0])
+    managerMembers.push(fullMembers[0]);
   }
 
-  managerMembers.forEach(m => {
-    sendApproveMail(sessionId, m)
-  })
+  managerMembers.forEach((m) => {
+    sendApproveMail(sessionId, m);
+  });
 }
 
 /**

--- a/packages/backend/src/core/research/remindResearch.ts
+++ b/packages/backend/src/core/research/remindResearch.ts
@@ -1,27 +1,17 @@
 import { SessionID, values } from '@research-vacant/common';
+import { sendRemindMail } from 'backend/source/mail';
 import { getAnsweredMemberIDs } from 'backend/source/spreadsheet/answers';
-import { getConfig } from 'backend/source/spreadsheet/config';
 import { getMembers } from 'backend/source/spreadsheet/members';
-import { getAnswerURL } from '../access/accessID';
 
 /**
  * セッションを確認し，対象者にリマインドメールを送信する
  */
-export function sendRemindMail(sessionId: SessionID) {
+export function sendRemind(sessionId: SessionID) {
   const members = values(getMembers());
   const answeredMembers = getAnsweredMemberIDs(sessionId);
-  const config = getConfig();
 
   // 未回答のメンバーのみにリマンインドを送信
   members
     .filter((m) => !answeredMembers.some((ansMem) => ansMem === m.id))
-    .forEach((m) =>
-      GmailApp.sendEmail(
-        m.mailAddress,
-        config.remindMailSubject,
-        `${config.remindMail}\n\n
-      【回答用サイトリンク】\n
-      ${getAnswerURL(sessionId, m.id)}`
-      )
-    );
+    .forEach((m) => sendRemindMail(sessionId, m));
 }

--- a/packages/backend/src/core/research/startResearch.ts
+++ b/packages/backend/src/core/research/startResearch.ts
@@ -1,8 +1,7 @@
 import { SessionID, values } from '@research-vacant/common';
+import { sendAnnounceMail } from 'backend/source/mail';
 import { initAnsRecordSheet } from 'backend/source/spreadsheet/answers';
-import { getConfig } from 'backend/source/spreadsheet/config';
 import { getMembers } from 'backend/source/spreadsheet/members';
-import { getAnswerURL } from '../access/accessID';
 
 /**
  * 調査開始
@@ -12,23 +11,13 @@ export function startSession(sessionId: SessionID) {
   initAnsRecordSheet(sessionId);
 
   // 案内メールの送付
-  sendAnnounceMail(sessionId);
+  sendAnnounce(sessionId);
 }
 
 /**
  * 部員全員に案内メールを送信する
  */
-function sendAnnounceMail(sessionId: SessionID) {
+function sendAnnounce(sessionId: SessionID) {
   const members = values(getMembers());
-  const config = getConfig();
-
-  members.forEach((m) =>
-    GmailApp.sendEmail(
-      m.mailAddress,
-      config.announceAnswerMailSubject,
-      `${config.announceAnswerMail}\n\n
-      【回答用サイトリンク】\n
-      ${getAnswerURL(sessionId, m.id)}`
-    )
-  );
+  members.forEach((m) => sendAnnounceMail(sessionId, m));
 }

--- a/packages/backend/src/source/mail.ts
+++ b/packages/backend/src/source/mail.ts
@@ -1,0 +1,70 @@
+import {
+  Member,
+  MemberID,
+  SessionID,
+  toEntries,
+} from '@research-vacant/common';
+import { getAnswerURL } from 'backend/core/access/accessID';
+import { getConfig } from './spreadsheet/config';
+
+/**
+ * 文中に設置されたマジックコードを置換する
+ *
+ * answerURLを使う場合は`sessionID`, `memberID`を指定する
+ */
+function replaceMagicCode(
+  message: string,
+  sessionId?: SessionID,
+  memberId?: MemberID
+) {
+  const answerURL =
+    sessionId && memberId ? getAnswerURL(sessionId, memberId) : undefined;
+  const magicCodes = {
+    '##_ANSWER_URL_##': answerURL ?? '##_ANSWER_URL_##',
+  };
+
+  let returnMessage = message;
+  toEntries(magicCodes).forEach((c) => {
+    returnMessage = returnMessage.replace(c[0], c[1]);
+  });
+  return returnMessage;
+}
+
+/**
+ * メンバーに回答依頼のメールを送信する
+ */
+export function sendAnnounceMail(sessionId: SessionID, member: Member) {
+  const config = getConfig();
+
+  GmailApp.sendEmail(
+    member.mailAddress,
+    config.announceAnswerMailSubject,
+    replaceMagicCode(config.announceAnswerMail, sessionId, member.id)
+  );
+}
+
+/**
+ * メンバーに回答依頼のリマインドメールを送信する
+ */
+export function sendRemindMail(sessionId: SessionID, member: Member) {
+  const config = getConfig();
+
+  GmailApp.sendEmail(
+    member.mailAddress,
+    config.remindMailSubject,
+    replaceMagicCode(config.remindMail, sessionId, member.id)
+  );
+}
+
+/**
+ * 管理者に日程確定の依頼メールを送信する
+ */
+export function sendApproveMail(sessionId: SessionID, member: Member) {
+  const config = getConfig();
+
+  GmailApp.sendEmail(
+    member.mailAddress,
+    config.requestApproveMailSubject,
+    replaceMagicCode(config.requestApproveMail, sessionId, member.id)
+  );
+}

--- a/packages/backend/src/source/places/base.ts
+++ b/packages/backend/src/source/places/base.ts
@@ -1,5 +1,6 @@
-import { AnsDate, RvDate } from '@research-vacant/common';
+import { AnsDate, RvDate, SessionID } from '@research-vacant/common';
 import dayjs, { Dayjs } from 'dayjs';
+import { getSessions } from '../spreadsheet/session';
 
 type DateRange = [RvDate, RvDate];
 
@@ -32,11 +33,16 @@ export abstract class Place {
 
 /**
  * 指定した日付の区間における施設利用可否情報を含む施設情報を返す
- * 
+ *
  * TODO: 運用コードに差替え
  */
-export async function loadPlaces(targetDateRange: DateRange) {
-  return [new SamplePlace(targetDateRange)]
+export function loadPlaces(sessionId: SessionID) {
+  const targetSessoin = getSessions()[sessionId];
+  const targetDateRange: DateRange = [
+    targetSessoin.researchRangeStart,
+    targetSessoin.researchRangeEnd,
+  ];
+  return [new SamplePlace(targetDateRange)];
 }
 
 /**

--- a/packages/backend/src/source/places/base.ts
+++ b/packages/backend/src/source/places/base.ts
@@ -8,6 +8,8 @@ export abstract class Place {
   abstract placeName: string;
   /** 施設情報に関するURL（地図や公式HP等） */
   abstract placeURL?: string;
+  /** 予約が必要な施設か？（必要な場合，予約を促すダイアログを表示する） */
+  abstract isNeedReserve: boolean;
 
   /** 取得する日付の範囲 */
   protected targetDateRange: DateRange;
@@ -29,12 +31,22 @@ export abstract class Place {
 }
 
 /**
+ * 指定した日付の区間における施設利用可否情報を含む施設情報を返す
+ * 
+ * TODO: 運用コードに差替え
+ */
+export async function loadPlaces(targetDateRange: DateRange) {
+  return [new SamplePlace(targetDateRange)]
+}
+
+/**
  * 開催場所の定義サンプル
  */
 class SamplePlace extends Place {
   placeName: string = '部室（サンプル開催場所）';
   placeURL?: string | undefined =
     'https://github.com/JRC-Chorus/ResearchVacant';
+  isNeedReserve: boolean = false;
 
   async getVacantInfo(): Promise<AnsDate[]> {
     // 対象の日付一覧を取得

--- a/packages/backend/src/source/places/base.ts
+++ b/packages/backend/src/source/places/base.ts
@@ -1,0 +1,87 @@
+import { AnsDate, RvDate } from '@research-vacant/common';
+import dayjs, { Dayjs } from 'dayjs';
+
+type DateRange = [RvDate, RvDate];
+
+export abstract class Place {
+  /** 施設名 */
+  abstract placeName: string;
+  /** 施設情報に関するURL（地図や公式HP等） */
+  abstract placeURL?: string;
+
+  /** 取得する日付の範囲 */
+  protected targetDateRange: DateRange;
+
+  constructor(targetDateRange: DateRange) {
+    this.targetDateRange = targetDateRange;
+  }
+
+  /** 期間内の日付一覧を返す */
+  protected getTargetDateRangeList() {
+    const startDay = dayjs(this.targetDateRange[0]);
+    const endDay = dayjs(this.targetDateRange[1]);
+    const dateCount = endDay.diff(startDay, 'day');
+    return [...Array(dateCount + 1)].map((_, idx) => startDay.add(idx, 'day'));
+  }
+
+  /** 取得した情報に基づいて，施設の空き日程の一覧を返す */
+  abstract getVacantInfo(): Promise<AnsDate[]>;
+}
+
+/**
+ * 開催場所の定義サンプル
+ */
+class SamplePlace extends Place {
+  placeName: string = '部室（サンプル開催場所）';
+  placeURL?: string | undefined =
+    'https://github.com/JRC-Chorus/ResearchVacant';
+
+  async getVacantInfo(): Promise<AnsDate[]> {
+    // 対象の日付一覧を取得
+    const allDate = this.getTargetDateRangeList();
+
+    // 外部API等から空き日程を取得する
+    const isVacants = await Promise.all(
+      allDate.map((d) => this.getIsVacant(d))
+    );
+
+    // 体裁を整えて返す
+    return allDate.map((d, idx) => {
+      return {
+        date: RvDate.parse(d.format()),
+        ans: isVacants[idx] ? 'OK' : 'NG',
+      };
+    });
+  }
+
+  /** 特定の日付の空き状況を取得する（API取得に100msかかる想定） */
+  protected getIsVacant(date: Dayjs) {
+    return new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(true), 100);
+    });
+  }
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  test('dummyPlace', async () => {
+    // define obj
+    const startDate = RvDate.parse('2024-10-1');
+    const endDate = RvDate.parse('2024-10-31');
+    const place = new SamplePlace([startDate, endDate]);
+
+    // run checker
+    const vacants = await place.getVacantInfo();
+
+    // test results
+    expect(vacants[0]).toMatchObject({
+      date: startDate,
+      ans: 'OK',
+    });
+    expect(vacants[vacants.length - 1]).toMatchObject({
+      date: endDate,
+      ans: 'OK',
+    });
+  });
+}

--- a/packages/common/schema/api.ts
+++ b/packages/common/schema/api.ts
@@ -10,7 +10,7 @@ export interface FrontAPI {
   researchManager: () => void;
 
   /** フロントエンドからのアクセスに対するレスポンスを定義 */
-  accessManager: (params: Record<string, string>) => MemberStatus;
+  accessManager: (params: Record<string, string>) => Promise<MemberStatus>;
   /** フロントエンドから回答を登録する */
   submitAnswers: (
     params: Record<string, string>,

--- a/packages/common/schema/app.ts
+++ b/packages/common/schema/app.ts
@@ -2,8 +2,9 @@
  * フロントエンドとの通信に関連のある型定義をおく
  */
 import { z } from 'zod';
-import { AnswerSummary, SummaryAnswers } from './db/answer';
+import { AnsDate, AnswerSummary, SummaryAnswers } from './db/answer';
 import { RvDate } from './db/common';
+import { OuterPlace } from './db/records';
 
 export const AccessID = z.string();
 export type AccessID = z.infer<typeof AccessID>;
@@ -13,9 +14,24 @@ export const UrlParams = z.object({
 });
 export type UrlParams = z.infer<typeof UrlParams>;
 
+export const CheckedOuterPlace = z.object({
+  /** 施設名 */
+  placeName: z.string(),
+  /** 施設情報に関するURL（地図や公式HP等） */
+  placeURL: z.string().optional(),
+  /** 予約が必要な施設か？（必要な場合，予約を促すダイアログを表示する） */
+  isNeedReserve: z.boolean(),
+  /** 予約状況 */
+  vacantInfo: AnsDate.array(),
+});
+export type CheckedOuterPlace = z.infer<typeof CheckedOuterPlace>;
+
 export const PartyDate = z.object({
+  /** イベントの開催日 */
   date: RvDate,
-  pos: z.string().optional(),
+  /** 開催場所 */
+  pos: OuterPlace,
+  /** 開催日の回答状況 */
   ans: SummaryAnswers,
 });
 export type PartyDate = z.infer<typeof PartyDate>;
@@ -45,6 +61,7 @@ const MSJudging = z.object({
   status: z.enum(['judging']),
   isManager: z.boolean(),
   summary: AnswerSummary,
+  places: CheckedOuterPlace.array(),
 });
 type MSJudging = z.infer<typeof MSJudging>;
 // 無効なURLでアクセス（セッションIDやメンバーIDが無効なときに使用）

--- a/packages/common/schema/db/records.ts
+++ b/packages/common/schema/db/records.ts
@@ -2,12 +2,21 @@ import { z } from 'zod';
 import { RvDate } from './common';
 import { SessionID } from './session';
 
+// 外部施設情報
+export const OuterPlace = z.object({
+  /** 施設名 */
+  placeName: z.string(),
+  /** 施設情報に関するURL（地図や公式HP等） */
+  placeURL: z.string().optional(),
+});
+export type OuterPlace = z.infer<typeof OuterPlace>;
+
 // 開催情報
 export const PartyInfo = z.object({
   /** 開催日 */
   date: RvDate,
   /** 開催場所 */
-  pos: z.string().optional(),
+  pos: OuterPlace,
 });
 export type PartyInfo = z.infer<typeof PartyInfo>;
 

--- a/packages/common/scripts/index.ts
+++ b/packages/common/scripts/index.ts
@@ -1,3 +1,4 @@
 export * from './obj/obj';
 export * from './obj/objmap';
+export * from './obj/pick';
 export * from './deepcopy';

--- a/packages/common/scripts/obj/pick.ts
+++ b/packages/common/scripts/obj/pick.ts
@@ -1,0 +1,6 @@
+/**
+ * 指定した配列から任意の要素を抽出する
+ */
+export function pickRandom<T>(targetArr: T[]): T {
+  return targetArr[Math.floor(Math.random() * targetArr.length)];
+}

--- a/packages/frontend/src/components/Calendar/ApproveDayBox.vue
+++ b/packages/frontend/src/components/Calendar/ApproveDayBox.vue
@@ -1,29 +1,29 @@
 <script setup lang="ts">
-import { AnsDate, AnsStatus } from '@research-vacant/common';
+import { AnsSummaryDate, CheckedOuterPlace } from '@research-vacant/common';
 
 interface Prop {
   day: number;
   disable?: boolean;
   disappear?: boolean;
+  ansDates: AnsSummaryDate[];
+  places: CheckedOuterPlace[];
 }
 const prop = defineProps<Prop>();
 
-const selecter = defineModel<AnsDate>();
+// TODO: 回答の状況に応じた値に変更する
+const selecter = 'OK';
 const classNames = () => {
   const returnClass = [];
-  returnClass.push(prop.disable ? 'disable' : `active-${selecter.value?.ans}`);
+  returnClass.push(prop.disable ? 'disable' : `active-${selecter}`);
   returnClass.push(prop.disappear ? 'disappear' : '');
   return returnClass.join(' ');
 };
 
+// TODO: クリック時に回答の詳細を表示するダイアログに遷移する
+// ダイアログ内で開催日の決定ボタンを設ける
+// ダイアログ内に「次の日付に遷移する」ボタンを設ける
 function onClicked() {
-  if (selecter.value) {
-    selecter.value.ans =
-      AnsStatus[
-        (AnsStatus.findIndex((v) => v === selecter.value?.ans) + 1) %
-          AnsStatus.length
-      ];
-  }
+  console.log(prop.ansDates);
 }
 </script>
 
@@ -37,11 +37,11 @@ function onClicked() {
     @click="onClicked()"
     :class="classNames()"
   >
-    <q-tooltip v-if="selecter?.ans === 'OK'"> 参加ＯＫ </q-tooltip>
-    <q-tooltip v-if="selecter?.ans === 'Pending'">
+    <!-- <q-tooltip v-if="selecter === 'OK'"> 参加ＯＫ </q-tooltip>
+    <q-tooltip v-if="selecter === 'Pending'">
       回答保留（可否未定）
     </q-tooltip>
-    <q-tooltip v-if="selecter?.ans === 'NG' && !disable"> 参加ＮＧ </q-tooltip>
+    <q-tooltip v-if="selecter === 'NG' && !disable"> 参加ＮＧ </q-tooltip> -->
     <div>
       <q-icon
         v-if="disable"
@@ -51,7 +51,7 @@ function onClicked() {
         class="absolute-center disable"
       />
       <q-icon
-        v-else-if="selecter?.ans === 'OK'"
+        v-else-if="selecter === 'OK'"
         name="check"
         color="primary"
         :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
@@ -59,14 +59,14 @@ function onClicked() {
       >
       </q-icon>
       <q-icon
-        v-else-if="selecter?.ans === 'Pending'"
+        v-else-if="selecter === 'Pending'"
         name="hourglass_empty"
         color="warning"
         :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
         class="absolute-center"
       />
       <q-icon
-        v-else-if="selecter?.ans === 'NG'"
+        v-else-if="selecter === 'NG'"
         name="close"
         color="negative"
         :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"

--- a/packages/frontend/src/components/Calendar/ApproveDayBox.vue
+++ b/packages/frontend/src/components/Calendar/ApproveDayBox.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { AnsDate, AnsStatus } from '@research-vacant/common';
+
+interface Prop {
+  day: number;
+  disable?: boolean;
+  disappear?: boolean;
+}
+const prop = defineProps<Prop>();
+
+const selecter = defineModel<AnsDate>();
+const classNames = () => {
+  const returnClass = [];
+  returnClass.push(prop.disable ? 'disable' : `active-${selecter.value?.ans}`);
+  returnClass.push(prop.disappear ? 'disappear' : '');
+  return returnClass.join(' ');
+};
+
+function onClicked() {
+  if (selecter.value) {
+    selecter.value.ans =
+      AnsStatus[
+        (AnsStatus.findIndex((v) => v === selecter.value?.ans) + 1) %
+          AnsStatus.length
+      ];
+  }
+}
+</script>
+
+<template>
+  <q-btn
+    round
+    dense
+    flat
+    :size="$q.screen.gt.xs ? '1.5rem' : '1rem'"
+    :disable="disable"
+    @click="onClicked()"
+    :class="classNames()"
+  >
+    <q-tooltip v-if="selecter?.ans === 'OK'"> 参加ＯＫ </q-tooltip>
+    <q-tooltip v-if="selecter?.ans === 'Pending'">
+      回答保留（可否未定）
+    </q-tooltip>
+    <q-tooltip v-if="selecter?.ans === 'NG' && !disable"> 参加ＮＧ </q-tooltip>
+    <div>
+      <q-icon
+        v-if="disable"
+        name="pause"
+        color="grey-5"
+        :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
+        class="absolute-center disable"
+      />
+      <q-icon
+        v-else-if="selecter?.ans === 'OK'"
+        name="check"
+        color="primary"
+        :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
+        class="absolute-center"
+      >
+      </q-icon>
+      <q-icon
+        v-else-if="selecter?.ans === 'Pending'"
+        name="hourglass_empty"
+        color="warning"
+        :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
+        class="absolute-center"
+      />
+      <q-icon
+        v-else-if="selecter?.ans === 'NG'"
+        name="close"
+        color="negative"
+        :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
+        class="absolute-center"
+      />
+      <div
+        class="absolute-center text-bold day-text"
+        :class="prop.disable ? 'disable' : ''"
+      >
+        {{ day }}
+      </div>
+    </div>
+  </q-btn>
+</template>
+
+<style scoped lang="scss">
+.active-OK {
+  border: 3px solid $primary;
+}
+.active-Pending {
+  border: 3px solid $warning;
+}
+.active-NG {
+  border: 3px solid $negative;
+}
+.disable {
+  opacity: 0.5;
+}
+
+.day-text {
+  text-shadow: 1px 1px 0px #fff, -1px -1px 0px #fff, -1px 1px 0px #fff,
+    1px -1px 0px #fff, 1px 0px 0px #fff, -1px 0px 0px #fff, 0px 1px 0px #fff,
+    0px -1px 0px #fff;
+}
+
+.disappear {
+  visibility: hidden;
+}
+</style>

--- a/packages/frontend/src/components/Calendar/script.ts
+++ b/packages/frontend/src/components/Calendar/script.ts
@@ -15,8 +15,7 @@ export function isEnableDate(summary: AnswerSummary, date?: RvDate): boolean {
   const startDay = dayjs(summary.ansDates[0].date);
   const endDay = dayjs(summary.ansDates[summary.ansDates.length - 1].date);
   const isInnerDateRange =
-    startDay.diff(targetDay, 'date') <= 0 &&
-    endDay.diff(targetDay, 'date') >= 0;
+    targetDay.isAfter(startDay, 'date') && targetDay.isBefore(endDay, 'date');
 
   // 休日か
   const mainStore = useMainStore();

--- a/packages/frontend/src/components/Calendar/script.ts
+++ b/packages/frontend/src/components/Calendar/script.ts
@@ -1,0 +1,28 @@
+import { AnswerSummary, keys, RvDate } from '@research-vacant/common';
+import dayjs from 'dayjs';
+import { useMainStore } from 'src/stores/main';
+
+/**
+ * 回答を求める必要がある日か
+ */
+export function isEnableDate(summary: AnswerSummary, date?: RvDate): boolean {
+  if (!date) {
+    return false;
+  }
+
+  // 日付は期間内か
+  const targetDay = dayjs(date);
+  const startDay = dayjs(summary.ansDates[0].date);
+  const endDay = dayjs(summary.ansDates[summary.ansDates.length - 1].date);
+  const isInnerDateRange =
+    startDay.diff(targetDay, 'date') <= 0 &&
+    endDay.diff(targetDay, 'date') >= 0;
+
+  // 休日か
+  const mainStore = useMainStore();
+  const isHoliday =
+    [0, 6].includes(targetDay.day()) ||
+    keys(mainStore.specialHoliday).includes(date);
+
+  return isInnerDateRange && !isHoliday;
+}

--- a/packages/frontend/src/components/CalendarView.vue
+++ b/packages/frontend/src/components/CalendarView.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
-import { AnswerSummary, deepcopy } from '@research-vacant/common';
+import { AnswerSummary, CheckedOuterPlace } from '@research-vacant/common';
 import { useMainStore } from 'src/stores/main';
+import ApproveDayBox from './Calendar/ApproveDayBox.vue';
 import DayBox from './Calendar/DayBox.vue';
+import { isEnableDate } from './Calendar/script';
 
 interface Prop {
   summary: AnswerSummary;
+  places?: CheckedOuterPlace[];
 }
 const prop = defineProps<Prop>();
 
 const youbi = ['日', '月', '火', '水', '木', '金', '土'];
 const mainStore = useMainStore();
 mainStore.initAnsModel(prop.summary);
-
-// 初期生成時点でNGの日付は無効にする
-const firstAllAns = deepcopy(mainStore.ansModel);
 
 /**
  * 祝日名を取得する
@@ -58,11 +58,19 @@ function getSpecialHolidayName(idx: number, isWindowSize_gt_sm: boolean) {
         >
           {{ getSpecialHolidayName(n, $q.screen.gt.sm) }}
         </div>
-        <DayBox
+        <ApproveDayBox
+          v-if="places"
           v-model="mainStore.ansModel[n - 1]"
           :day="n - mainStore.ansModel.findIndex((a) => !!a)"
           :disappear="!mainStore.ansModel[n - 1]"
-          :disable="firstAllAns[n - 1]?.ans === 'NG'"
+          :disable="!isEnableDate(summary, mainStore.ansModel[n - 1]?.date)"
+        />
+        <DayBox
+          v-else
+          v-model="mainStore.ansModel[n - 1]"
+          :day="n - mainStore.ansModel.findIndex((a) => !!a)"
+          :disappear="!mainStore.ansModel[n - 1]"
+          :disable="!isEnableDate(summary, mainStore.ansModel[n - 1]?.date)"
         />
       </div>
     </div>

--- a/packages/frontend/src/components/CalendarView.vue
+++ b/packages/frontend/src/components/CalendarView.vue
@@ -60,10 +60,11 @@ function getSpecialHolidayName(idx: number, isWindowSize_gt_sm: boolean) {
         </div>
         <ApproveDayBox
           v-if="places"
-          v-model="mainStore.ansModel[n - 1]"
           :day="n - mainStore.ansModel.findIndex((a) => !!a)"
           :disappear="!mainStore.ansModel[n - 1]"
           :disable="!isEnableDate(summary, mainStore.ansModel[n - 1]?.date)"
+          :ans-dates="summary.ansDates"
+          :places="places"
         />
         <DayBox
           v-else

--- a/packages/frontend/src/components/utils/IndentLine.vue
+++ b/packages/frontend/src/components/utils/IndentLine.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { defineProps } from 'vue';
-
 interface Prop {
   title: string;
   minWidth?: string;

--- a/packages/frontend/src/pages/IndexPage.vue
+++ b/packages/frontend/src/pages/IndexPage.vue
@@ -2,6 +2,7 @@
 import { onMounted, Ref, ref } from 'vue';
 import { MemberStatus } from '@research-vacant/common';
 import { useMainStore } from 'src/stores/main';
+import ApprovePage from './Sub/ApprovePage.vue';
 import CalendarPage from './Sub/CalendarPage.vue';
 import ErrorPage from './Sub/ErrorPage.vue';
 import LoadingPage from './Sub/LoadingPage.vue';
@@ -42,6 +43,11 @@ onMounted(async () => {
           '開催日の決定はＢＯＴの管理者が行っています．',
           '管理者が開催日を決定するまで，今しばらくお待ちください．',
         ]"
+      />
+      <ApprovePage
+        v-else-if="status.status === 'judging'"
+        :summary="status.summary"
+        :places="status.places"
       />
       <CalendarPage v-else :summary="status.summary" />
     </div>

--- a/packages/frontend/src/pages/IndexPage.vue
+++ b/packages/frontend/src/pages/IndexPage.vue
@@ -38,9 +38,9 @@ onMounted(async () => {
       />
       <ErrorPage
         v-else-if="status.status === 'judging' && !status.isManager"
-        title="調査結果をもとに開催日を決定中です"
+        title="開催日を決定中です"
         :message="[
-          '開催日の決定はＢＯＴの管理者が行っています．',
+          '開催日の決定は調査結果をもとにＢＯＴの管理者が行っています．',
           '管理者が開催日を決定するまで，今しばらくお待ちください．',
         ]"
       />

--- a/packages/frontend/src/pages/Sub/ApprovePage.vue
+++ b/packages/frontend/src/pages/Sub/ApprovePage.vue
@@ -116,7 +116,7 @@ function resetAllAns() {
           </div>
         </div>
         <div style="max-width: min(90vw, 50rem); margin: 0 auto">
-          <CalendarView :summary="summary" />
+          <CalendarView :summary="summary" :places="places" />
         </div>
       </div>
 

--- a/packages/frontend/src/pages/Sub/ApprovePage.vue
+++ b/packages/frontend/src/pages/Sub/ApprovePage.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { useQuasar } from 'quasar';
+import { AnswerSummary, CheckedOuterPlace } from '@research-vacant/common';
+import dayjs from 'dayjs';
+import CalendarView from 'src/components/CalendarView.vue';
+import AnsSendingDialog from 'src/components/Dialogs/AnsSendingDialog.vue';
+import CheckDialog from 'src/components/Dialogs/CheckDialog.vue';
+import {
+  CheckDialogProp,
+  InfoDialogProp,
+  ShowingDetail,
+} from 'src/components/Dialogs/iDialogProp';
+import InfoDialog from 'src/components/Dialogs/InfoDialog.vue';
+import IndentLine from 'src/components/utils/IndentLine.vue';
+import { useMainStore } from 'src/stores/main';
+
+interface Prop {
+  summary: AnswerSummary;
+  places: CheckedOuterPlace[];
+}
+const prop = defineProps<Prop>();
+
+const $q = useQuasar();
+const mainStore = useMainStore();
+
+const showingDetails: ShowingDetail[] = [
+  {
+    title: '開催回数',
+    // TODO: データベースにこの項目が記録できるフィールドを追加し，MemberSummaryから取得できるようにする
+    // TODO: 管理者は個々のテキストをUI上から変更できるような機能を入れる
+    desc: '２回（そのうち１回は外部練習を予定）',
+  },
+  {
+    title: '備考',
+    // TODO: データベースにこの項目が記録できるフィールドを追加し，MemberSummaryから取得できるようにする
+    // TODO: 管理者は個々のテキストをUI上から変更できるような機能を入れる
+    desc: '＜特になし＞',
+  },
+];
+
+/**
+ * 回答の提出処理を実行
+ */
+function submitAns() {
+  $q.dialog({
+    component: AnsSendingDialog,
+  });
+}
+
+/**
+ * 調査情報の詳細を表示（スマホ版）
+ */
+function showInfoDialog() {
+  $q.dialog({
+    component: InfoDialog,
+    componentProps: {
+      showingDetails: showingDetails,
+    } as InfoDialogProp,
+  });
+}
+
+/**
+ * 入力内容のリセット
+ */
+function resetAllAns() {
+  $q.dialog({
+    component: CheckDialog,
+    componentProps: {
+      title: '入力内容のリセット',
+      message:
+        '決定済みの開催情報がリセットされます．\n入力内容を削除してもよろしいですか．',
+      okTxt: 'ＯＫ',
+      cancelTxt: 'キャンセル',
+    } as CheckDialogProp,
+  }).onOk(() => {
+    mainStore.isEnableReload = false;
+    mainStore.initAnsModel(prop.summary);
+    mainStore.freeTxt = '';
+  });
+}
+</script>
+
+<template>
+  <q-card flat class="col column">
+    <q-card-section class="col column items-center">
+      <div class="col"></div>
+      <!-- main display -->
+      <div class="col row">
+        <div class="col" style="min-width: 15rem">
+          <div class="row justify-between items-center">
+            <h1 class="text-bold">
+              {{ `${dayjs(summary.ansDates[0].date).month() + 1}月の日程調整` }}
+            </h1>
+            <q-btn
+              flat
+              round
+              dense
+              icon="info"
+              color="info"
+              size="1.2rem"
+              class="lt-lg"
+              @click="showInfoDialog()"
+            />
+          </div>
+          <p>回答結果をもとに開催日を決定してください．</p>
+
+          <div class="gt-md">
+            <h2><u>開催日の詳細情報</u></h2>
+            <ul>
+              <li v-for="detail in showingDetails" :key="detail.title">
+                <IndentLine :title="detail.title" max-width="10rem">
+                  {{ detail.desc }}
+                </IndentLine>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div style="max-width: min(90vw, 50rem); margin: 0 auto">
+          <CalendarView :summary="summary" />
+        </div>
+      </div>
+
+      <!-- free text -->
+      <div class="col fit" style="max-width: min(95vw, 80rem)">
+        <h2>フリーメッセージ</h2>
+        <q-input v-model="mainStore.freeTxt" filled style="font-size: 1rem" />
+      </div>
+    </q-card-section>
+
+    <q-separator />
+
+    <q-card-actions align="right">
+      <div class="row q-gutter-x-lg q-py-sm">
+        <q-btn outline size="1rem" @click="resetAllAns()">
+          入力内容をリセット
+        </q-btn>
+        <q-btn fill color="primary" size="1rem" @click="submitAns()">
+          回答を提出
+        </q-btn>
+      </div>
+    </q-card-actions>
+  </q-card>
+</template>

--- a/packages/frontend/src/pages/Sub/CalendarPage.vue
+++ b/packages/frontend/src/pages/Sub/CalendarPage.vue
@@ -27,13 +27,12 @@ const startDate = dayjs(prop.summary.ansDates[0].date);
 const endDate = dayjs(
   prop.summary.ansDates[prop.summary.ansDates.length - 1].date
 );
-const showingDateFormat = 'YYYY年MM月DD日';
 
 const showingDetails: ShowingDetail[] = [
   {
     title: '回答期間',
-    desc: `${startDate.format(showingDateFormat)} ～ ${endDate.format(
-      showingDateFormat
+    desc: `${startDate.format(mainStore.showingDateFormat)} ～ ${endDate.format(
+      mainStore.showingDateFormat
     )}`,
   },
   {

--- a/packages/frontend/src/scripts/accessCases.ts
+++ b/packages/frontend/src/scripts/accessCases.ts
@@ -11,26 +11,6 @@ import {
 } from '@research-vacant/common';
 
 /**
- * ダミーメンバー
- */
-const sampleMember: Member = {
-  id: MemberID.parse('1ef26ba4-f7b6-4616-9da6-263223fef29b'),
-  firstName: 'サンプル',
-  lastName: '太郎',
-  mailAddress: 'sample-taro@email.com',
-};
-
-/**
- * ダミー施設
- */
-const samplePlace: CheckedOuterPlace = {
-  placeName: 'サンプル施設',
-  placeURL: 'https://github.com/JRC-Chorus/ResearchVacant',
-  isNeedReserve: true,
-  vacantInfo: getRandomAns(),
-};
-
-/**
  * 回答対象日
  */
 const defaultAnsDates: AnswerSummary['ansDates'] = [
@@ -53,6 +33,26 @@ const defaultAnsDates: AnswerSummary['ansDates'] = [
   { date: RvDate.parse('2024-10-17'), ans: [] },
   { date: RvDate.parse('2024-10-18'), ans: [] },
 ];
+
+/**
+ * ダミーメンバー
+ */
+const sampleMember: Member = {
+  id: MemberID.parse('1ef26ba4-f7b6-4616-9da6-263223fef29b'),
+  firstName: 'サンプル',
+  lastName: '太郎',
+  mailAddress: 'sample-taro@email.com',
+};
+
+/**
+ * ダミー施設
+ */
+const samplePlace: CheckedOuterPlace = {
+  placeName: 'サンプル施設',
+  placeURL: 'https://github.com/JRC-Chorus/ResearchVacant',
+  isNeedReserve: true,
+  vacantInfo: getRandomAns(),
+};
 
 /**
  * デフォルトで指定した日付群に対して，適当な回答を付与した回答群を生成

--- a/packages/frontend/src/scripts/accessCases.ts
+++ b/packages/frontend/src/scripts/accessCases.ts
@@ -1,0 +1,150 @@
+import {
+  AnswerSummary,
+  CheckedOuterPlace,
+  deepcopy,
+  Member,
+  MemberID,
+  MemberStatus,
+  OuterPlace,
+  pickRandom,
+  RvDate,
+} from '@research-vacant/common';
+
+/**
+ * ダミーメンバー
+ */
+const sampleMember: Member = {
+  id: MemberID.parse('1ef26ba4-f7b6-4616-9da6-263223fef29b'),
+  firstName: 'サンプル',
+  lastName: '太郎',
+  mailAddress: 'sample-taro@email.com',
+};
+
+/**
+ * ダミー施設
+ */
+const samplePlace: CheckedOuterPlace = {
+  placeName: 'サンプル施設',
+  placeURL: 'https://github.com/JRC-Chorus/ResearchVacant',
+  isNeedReserve: true,
+  vacantInfo: getRandomAns(),
+};
+
+/**
+ * 回答対象日
+ */
+const defaultAnsDates: AnswerSummary['ansDates'] = [
+  { date: RvDate.parse('2024-10-1'), ans: [] },
+  { date: RvDate.parse('2024-10-2'), ans: [] },
+  { date: RvDate.parse('2024-10-3'), ans: [] },
+  { date: RvDate.parse('2024-10-4'), ans: [] },
+  { date: RvDate.parse('2024-10-5'), ans: [] },
+  { date: RvDate.parse('2024-10-6'), ans: [] },
+  { date: RvDate.parse('2024-10-7'), ans: [] },
+  { date: RvDate.parse('2024-10-8'), ans: [] },
+  { date: RvDate.parse('2024-10-9'), ans: [] },
+  { date: RvDate.parse('2024-10-10'), ans: [] },
+  { date: RvDate.parse('2024-10-11'), ans: [] },
+  { date: RvDate.parse('2024-10-12'), ans: [] },
+  { date: RvDate.parse('2024-10-13'), ans: [] },
+  { date: RvDate.parse('2024-10-14'), ans: [] },
+  { date: RvDate.parse('2024-10-15'), ans: [] },
+  { date: RvDate.parse('2024-10-16'), ans: [] },
+  { date: RvDate.parse('2024-10-17'), ans: [] },
+  { date: RvDate.parse('2024-10-18'), ans: [] },
+];
+
+/**
+ * デフォルトで指定した日付群に対して，適当な回答を付与した回答群を生成
+ */
+function getRandomAns() {
+  return defaultAnsDates.map((defaultAns) => {
+    return {
+      date: defaultAns.date,
+      ans: pickRandom(['OK', 'NG', 'Pending'] as const),
+    };
+  });
+}
+
+/**
+ * accessManagerの戻り値を生成する（開発用のダミーデータを生成）
+ */
+export function loadAccessMock(status: MemberStatus['status']): MemberStatus {
+  switch (status) {
+    case 'noAns':
+      return {
+        status,
+        summary: {
+          ansDates: defaultAnsDates,
+          freeTxts: [],
+        },
+      };
+    case 'alreadyAns':
+      return {
+        status,
+        summary: {
+          ansDates: defaultAnsDates,
+          selfAns: {
+            userId: sampleMember.id,
+            userName: `${sampleMember.firstName} ${sampleMember.lastName}`,
+            freeText: '前回の入力',
+            ansDates: getRandomAns(),
+          },
+          freeTxts: [],
+        },
+      };
+    case 'finished':
+      return {
+        status,
+        summary: {
+          ansDates: defaultAnsDates,
+          freeTxts: [],
+        },
+        partyDates: [
+          {
+            date: defaultAnsDates[7].date,
+            ans: [
+              {
+                status: 'OK',
+                ansPersonNames: [
+                  `${sampleMember.firstName} ${sampleMember.lastName}`,
+                ],
+              },
+              {
+                status: 'NG',
+                ansPersonNames: [],
+              },
+              {
+                status: 'Pending',
+                ansPersonNames: [],
+              },
+            ],
+            pos: OuterPlace.parse(samplePlace),
+          },
+        ],
+      };
+    case 'judging':
+      // 適当にデータを追加
+      const judgingAnsDates = deepcopy(defaultAnsDates).map((ans) => {
+        ans.ans.push({
+          status: pickRandom(['OK', 'NG', 'Pending'] as const),
+          ansPersonNames: [
+            `${sampleMember.firstName} ${sampleMember.lastName}`,
+          ],
+        });
+        return ans;
+      });
+      return {
+        status,
+        summary: {
+          ansDates: judgingAnsDates,
+          freeTxts: [],
+        },
+        isManager: true,
+        places: [samplePlace],
+      };
+    case 'invalidUser':
+    case 'beforeOpening':
+      return { status };
+  }
+}

--- a/packages/frontend/src/scripts/api.ts
+++ b/packages/frontend/src/scripts/api.ts
@@ -14,8 +14,8 @@ const mockFuncs: IRun = {
   },
   accessManager: function (
     params: Record<string, string>
-  ): Promise<MemberStatus> {
-    return new Promise((resolve) => {
+  ): Promise<Promise<MemberStatus>> {
+    const target = new Promise<MemberStatus>((resolve) => {
       resolve({
         status: 'noAns',
         summary: {
@@ -42,6 +42,10 @@ const mockFuncs: IRun = {
           freeTxts: [],
         },
       });
+    });
+
+    return new Promise((resolve) => {
+      resolve(target);
     });
   },
   submitAnswers(params, ans, freeTxt) {

--- a/packages/frontend/src/scripts/api.ts
+++ b/packages/frontend/src/scripts/api.ts
@@ -1,6 +1,7 @@
-import { MemberStatus, RvDate } from '@research-vacant/common';
+import { MemberStatus } from '@research-vacant/common';
 import { IRun, IUrlLocation } from 'src/schema/global';
 import { useMainStore } from 'src/stores/main';
+import { loadAccessMock } from './accessCases';
 
 const mockFuncs: IRun = {
   doGet: function (e: any): Promise<GoogleAppsScript.HTML.HtmlOutput> {
@@ -16,32 +17,7 @@ const mockFuncs: IRun = {
     params: Record<string, string>
   ): Promise<Promise<MemberStatus>> {
     const target = new Promise<MemberStatus>((resolve) => {
-      resolve({
-        status: 'noAns',
-        summary: {
-          ansDates: [
-            { date: RvDate.parse('2024-10-1'), ans: [] },
-            { date: RvDate.parse('2024-10-2'), ans: [] },
-            { date: RvDate.parse('2024-10-3'), ans: [] },
-            { date: RvDate.parse('2024-10-4'), ans: [] },
-            { date: RvDate.parse('2024-10-5'), ans: [] },
-            { date: RvDate.parse('2024-10-6'), ans: [] },
-            { date: RvDate.parse('2024-10-7'), ans: [] },
-            { date: RvDate.parse('2024-10-8'), ans: [] },
-            { date: RvDate.parse('2024-10-9'), ans: [] },
-            { date: RvDate.parse('2024-10-10'), ans: [] },
-            { date: RvDate.parse('2024-10-11'), ans: [] },
-            { date: RvDate.parse('2024-10-12'), ans: [] },
-            { date: RvDate.parse('2024-10-13'), ans: [] },
-            { date: RvDate.parse('2024-10-14'), ans: [] },
-            { date: RvDate.parse('2024-10-15'), ans: [] },
-            { date: RvDate.parse('2024-10-16'), ans: [] },
-            { date: RvDate.parse('2024-10-17'), ans: [] },
-            { date: RvDate.parse('2024-10-18'), ans: [] },
-          ],
-          freeTxts: [],
-        },
-      });
+      resolve(loadAccessMock('noAns'));
     });
 
     return new Promise((resolve) => {

--- a/packages/frontend/src/scripts/api.ts
+++ b/packages/frontend/src/scripts/api.ts
@@ -17,7 +17,7 @@ const mockFuncs: IRun = {
     params: Record<string, string>
   ): Promise<Promise<MemberStatus>> {
     const target = new Promise<MemberStatus>((resolve) => {
-      resolve(loadAccessMock('alreadyAns'));
+      resolve(loadAccessMock('judging'));
     });
 
     return new Promise((resolve) => {

--- a/packages/frontend/src/scripts/api.ts
+++ b/packages/frontend/src/scripts/api.ts
@@ -17,7 +17,7 @@ const mockFuncs: IRun = {
     params: Record<string, string>
   ): Promise<Promise<MemberStatus>> {
     const target = new Promise<MemberStatus>((resolve) => {
-      resolve(loadAccessMock('noAns'));
+      resolve(loadAccessMock('alreadyAns'));
     });
 
     return new Promise((resolve) => {

--- a/packages/frontend/src/stores/main.ts
+++ b/packages/frontend/src/stores/main.ts
@@ -23,6 +23,8 @@ export const useMainStore = defineStore('mainStore', {
     freeTxt: '',
     /** 再読み込み可能か */
     isEnableReload: false,
+    /** 日付の標準フォーマット */    
+    showingDateFormat: 'YYYY年MM月DD日',
     /** バックエンドとの通信でエラーがあった場合に格納 */
     error: null as Error | null,
   }),

--- a/packages/frontend/src/stores/main.ts
+++ b/packages/frontend/src/stores/main.ts
@@ -23,7 +23,7 @@ export const useMainStore = defineStore('mainStore', {
     freeTxt: '',
     /** 再読み込み可能か */
     isEnableReload: false,
-    /** 日付の標準フォーマット */    
+    /** 日付の標準フォーマット */
     showingDateFormat: 'YYYY年MM月DD日',
     /** バックエンドとの通信でエラーがあった場合に格納 */
     error: null as Error | null,
@@ -93,7 +93,7 @@ export const useMainStore = defineStore('mainStore', {
               ) {
                 return holidayCheck
                   ? 'NG'
-                  : summary.selfAns?.ansDates[idx].ans ?? 'OK';
+                  : summary.selfAns?.ansDates.at(idx)?.ans ?? 'OK';
               } else {
                 // 期間外の日付はすべてNG扱い
                 return 'NG';


### PR DESCRIPTION
# 概要

外部施設を追加するためのプラグインを`packages\backend\src\source\places`に作成

現状では「サンプル施設」を返す実装としており，運用時の施設を保存する方法については検討中


## 変更箇所
- 外部施設プラグインの作成
- 承認時の処理とフロントエンドに必要な情報を渡す機構を作成
- フロントエンドにおけるバックエンドからの通信内容に関するモックを作成
- メールを一元化
