### PR TITLE
Teamsへの通知処理を実装

### DIFF
--- a/packages/backend/src/core/access.ts
+++ b/packages/backend/src/core/access.ts
@@ -18,6 +18,7 @@ import {
 } from 'backend/source/spreadsheet/decideRecord';
 import { getMembers } from 'backend/source/spreadsheet/members';
 import { getSessions, updateSession } from 'backend/source/spreadsheet/session';
+import { sendNotifyPartyDate4Teams } from 'backend/source/teams';
 import { isMember, parseRecievedIds } from './access/checker';
 
 /**
@@ -147,7 +148,8 @@ export function decideDates(
   // 開催日を登録
   registPartyDate(ids.sessionId, infos);
 
-  // TODO: 決定を通知（Teams？）
+  // 決定を通知
+  sendNotifyPartyDate4Teams(infos);
 
   // ステータスを更新
   updateSession(ids.sessionId, 'closed');

--- a/packages/backend/src/core/access.ts
+++ b/packages/backend/src/core/access.ts
@@ -12,6 +12,7 @@ import {
   getAnswerSummary,
   registAnswer,
 } from 'backend/source/spreadsheet/answers';
+import { getConfig } from 'backend/source/spreadsheet/config';
 import {
   getPartys,
   registPartyDate,
@@ -149,7 +150,13 @@ export function decideDates(
   registPartyDate(ids.sessionId, infos);
 
   // 決定を通知
-  sendNotifyPartyDate4Teams(infos);
+  const config = getConfig();
+  sendNotifyPartyDate4Teams(
+    config.teamsLink,
+    config.teamsTitle,
+    config.teamsDesc,
+    infos
+  );
 
   // ステータスを更新
   updateSession(ids.sessionId, 'closed');

--- a/packages/backend/src/core/research/decideHoldingDate.ts
+++ b/packages/backend/src/core/research/decideHoldingDate.ts
@@ -21,12 +21,3 @@ export function sendJudgeCandidate(sessionId: SessionID) {
     sendApproveMail(sessionId, m);
   });
 }
-
-/**
- * 決定日をTeamsに通知する
- */
-export function notify4Teams() {
-  // teams.send()
-}
-
-// TODO: 候補日の絞り方に関するテストを記述する

--- a/packages/backend/src/source/places/base.ts
+++ b/packages/backend/src/source/places/base.ts
@@ -74,9 +74,15 @@ export function loadPlaces(sessionId: SessionID): Promise<CheckedOuterPlace[]> {
 /**
  * PlaceIDで指定された施設の情報を取得する（空き情報は取得しない）
  */
-export function loadPlaceProps(placeId: PlaceID) {
+export function loadPlaceProps(): (OuterPlace & { placeId: PlaceID })[];
+export function loadPlaceProps(placeId: PlaceID): OuterPlace;
+export function loadPlaceProps(placeId?: PlaceID) {
   const places = ALL_PLACE_GETTERS.map((getter) => getter.getObj());
-  return OuterPlace.parse(places.find((p) => p.placeId === placeId));
+  if (placeId) {
+    return OuterPlace.parse(places.find((p) => p.placeId === placeId));
+  } else {
+    return places;
+  }
 }
 
 /** In Source Testing */

--- a/packages/backend/src/source/places/secrets/sample.ts
+++ b/packages/backend/src/source/places/secrets/sample.ts
@@ -12,6 +12,7 @@ const BASE_INFO: OuterPlace = {
   placeURL: 'https://github.com/JRC-Chorus/ResearchVacant',
   isNeedReserve: false,
 };
+let samplePlace: OuterPlace & { placeId: PlaceID };
 
 /**
  * 開催場所の定義サンプル（施設の空き状況情報なし）
@@ -31,7 +32,10 @@ export async function getSamplePlaceWithVacants(
  * 開催場所の定義サンプル（施設の空き状況情報なし）
  */
 export function getSamplePlace(genId: (p: OuterPlace) => PlaceID) {
-  return Object.assign(BASE_INFO, { placeId: genId(BASE_INFO) });
+  if (!samplePlace) {
+    samplePlace = Object.assign(BASE_INFO, { placeId: genId(BASE_INFO) });
+  }
+  return samplePlace;
 }
 
 /**

--- a/packages/backend/src/source/spreadsheet/answers.ts
+++ b/packages/backend/src/source/spreadsheet/answers.ts
@@ -109,7 +109,7 @@ export function getAnsweredMemberIDs(sessionId: SessionID) {
  */
 export function getAnswerSummary(
   session: Session,
-  accessedMemberId: MemberID
+  accessedMemberId?: MemberID
 ): AnswerSummary {
   const answers = values(getAnswers(session.id));
 

--- a/packages/backend/src/source/spreadsheet/config.ts
+++ b/packages/backend/src/source/spreadsheet/config.ts
@@ -30,7 +30,8 @@ const configShowingKey: { [key in keyof Config]: string } = {
   requestApproveMailSubject: '下記承認メールの文面',
   requestApproveMail:
     '管理者に調査結果を通知し，開催日承認を依頼するメールの文面',
-  announceDecidedDateNotice: '決定した開催日をTeamsで通知する際のTeamsの文面',
+  teamsTitle: '開催日決定後のTeams通知におけるカードのタイトル',
+  teamsDesc: '開催日決定後のTeams通知におけるカードに記載するメッセージ',
 };
 
 let configCache: Config | undefined;

--- a/packages/backend/src/source/teams.ts
+++ b/packages/backend/src/source/teams.ts
@@ -1,0 +1,127 @@
+import { PartyInfo, SHOWING_DATE_FORMAT } from '@research-vacant/common';
+import dayjs from 'dayjs';
+import https from 'https';
+import { loadPlaceProps } from './places/base';
+import { getConfig } from './spreadsheet/config';
+
+/**
+ * Teamsへのメッセージ送信の基本関数
+ *
+ * カードのデザインを作成するツール
+ * @url https://www.adaptivecards.io/designer/
+ */
+async function buildMessage(title: string, infos: PartyInfo[], desc: string) {
+  // 場所一覧
+  const places = infos.map<any>((info, idx) => {
+    const targetPlace = loadPlaceProps(info.placeId);
+    return {
+      type: 'TextBlock',
+      text: `${dayjs(info.date).format(SHOWING_DATE_FORMAT)} ＠${
+        targetPlace.placeName
+      }`,
+      weight: 'Bolder',
+      size: 'Large',
+      separator: idx === 0,
+      horizontalAlignment: 'Center',
+      spacing: 'Small',
+    };
+  });
+
+  // 場所一覧のトップにテキストを追加
+  places.unshift({
+    type: 'TextBlock',
+    text: '開催日',
+    weight: 'Bolder',
+    horizontalAlignment: 'Center',
+  });
+
+  // 返却するスタイル定義
+  const returnObj: any[] = [
+    {
+      type: 'TextBlock',
+      text: title,
+      wrap: true,
+      size: 'large',
+      weight: 'bolder',
+    },
+    {
+      type: 'Container',
+      items: places,
+      backgroundImage: {
+        fillMode: 'Repeat',
+        horizontalAlignment: 'Center',
+        verticalAlignment: 'Center',
+      },
+      style: 'accent',
+    },
+    {
+      type: 'TextBlock',
+      text: desc,
+      wrap: true,
+    },
+  ];
+
+  return returnObj;
+}
+
+function sendRequest(url: string, data: any) {
+  const parsedUrl = new URL(url);
+  const options = {
+    hostname: parsedUrl.hostname,
+    path: parsedUrl.pathname + parsedUrl.search, // パスとクエリパラメータを結合
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(data),
+    },
+  };
+
+  const req = https.request(options, (res) => {
+    let responseBody = '';
+
+    res.on('data', (chunk) => {
+      responseBody += chunk;
+    });
+
+    res.on('end', () => {
+      if (res.statusCode === 200 || res.statusCode === 202) {
+        console.log('メッセージが送信されました');
+      } else {
+        console.error(
+          `エラーが発生しました: ${res.statusCode}, ${responseBody}`
+        );
+      }
+    });
+  });
+
+  req.on('error', (e) => {
+    console.error(`リクエストエラー: ${e.message}`);
+  });
+
+  req.write(data);
+  req.end();
+}
+
+/**
+ * Teamsで決定した開催日の情報を送信する
+ */
+export function sendNotifyPartyDate4Teams(infos: PartyInfo[]) {
+  const config = getConfig();
+  const messageBody = buildMessage(config.teamsTitle, infos, config.teamsDesc);
+
+  const jsonData = JSON.stringify({
+    attachments: [
+      {
+        contentType: 'application/vnd.microsoft.card.adaptive',
+        content: {
+          $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+          version: '1.5',
+          type: 'AdaptiveCard',
+          body: messageBody,
+        },
+      },
+    ],
+  });
+
+  sendRequest(config.teamsLink, jsonData);
+}

--- a/packages/common/schema/db/common.ts
+++ b/packages/common/schema/db/common.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // 日付型
 const DATE_FORMAT = 'YYYY-MM-DD';
+export const SHOWING_DATE_FORMAT = 'YYYY年MM月DD日';
 export const RvDate = z.preprocess(
   (val) => dayjs(String(val)).format(DATE_FORMAT),
   z.string().date().brand('RvDate')

--- a/packages/common/schema/db/config.ts
+++ b/packages/common/schema/db/config.ts
@@ -101,11 +101,16 @@ export const Config = z.object({
     .optional()
     .default('【日程調査】開催日の承認依頼'),
 
-  /** Teamsへの通知メッセージ */
-  announceDecidedDateNotice: z
+  /** Teamsで表示するときのタイトル */
+  teamsTitle: z.string().optional().default('日程調整結果'),
+
+  /** Teamsで表示するときの説明文 */
+  teamsDesc: z
     .string()
     .optional()
-    .default('開催日が決定しました．当日はお気をつけてご出席ください．'),
+    .default(
+      '@Team\n\n日程調整結果です．\n\n調整の結果，開催日は上記日程の**13：00～**で確定となりました．\n\nよろしくお願いいたします．'
+    ),
 
   // 将来的にはメールの内容もconfigから受け取る？
 });

--- a/packages/frontend/src/components/Dialogs/AnswerListDialog.vue
+++ b/packages/frontend/src/components/Dialogs/AnswerListDialog.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { Ref, ref } from 'vue';
 import { useDialogPluginComponent } from 'quasar';
-import { CheckedOuterPlace, keys, RvDate } from '@research-vacant/common';
+import {
+  CheckedOuterPlace,
+  keys,
+  RvDate,
+  SHOWING_DATE_FORMAT,
+} from '@research-vacant/common';
 import dayjs from 'dayjs';
 import { useMainStore } from 'src/stores/main';
 import { iconList, isEnableDate } from '../Calendar/script';
@@ -64,9 +69,7 @@ function onUnmarkClicked() {
   <!-- TODO: Update a BAAAAAAAAAAD Design -->
   <q-dialog ref="dialogRef" @hide="onDialogHide" persistent>
     <BaseDialog
-      :title="`${dayjs(showingDate).format(
-        mainStore.showingDateFormat
-      )}の回答一覧`"
+      :title="`${dayjs(showingDate).format(SHOWING_DATE_FORMAT)}の回答一覧`"
       @close="onDialogCancel"
       style="width: 40rem; max-width: 100vw; max-height: 90vh"
     >

--- a/packages/frontend/src/components/Dialogs/SendingDialog/ApproveDateCard.vue
+++ b/packages/frontend/src/components/Dialogs/SendingDialog/ApproveDateCard.vue
@@ -5,6 +5,7 @@ import {
   AnswerSummary,
   CheckedOuterPlace,
   RvDate,
+  SHOWING_DATE_FORMAT,
 } from '@research-vacant/common';
 import dayjs from 'dayjs';
 import { useMainStore } from 'src/stores/main';
@@ -58,7 +59,7 @@ const cardItems = [
         class="text-primary text-bold q-mt-sm q-mb-md"
         style="font-size: 1.2rem; text-decoration: underline"
       >
-        {{ dayjs(targetDate).format(mainStore.showingDateFormat) }}
+        {{ dayjs(targetDate).format(SHOWING_DATE_FORMAT) }}
       </div>
 
       <q-list>

--- a/packages/frontend/src/stores/main.ts
+++ b/packages/frontend/src/stores/main.ts
@@ -4,6 +4,7 @@ import {
   MemberStatus,
   PlaceID,
   RvDate,
+  SHOWING_DATE_FORMAT,
 } from '@research-vacant/common';
 import dayjs from 'dayjs';
 import { isHoliday } from 'japanese-holidays';
@@ -34,8 +35,6 @@ export const useMainStore = defineStore('mainStore', {
     isEnableReload: false,
     /** 承認画面を表示するか（回答期間中） */
     isShowApproverView: false,
-    /** 日付の標準フォーマット */
-    showingDateFormat: 'YYYY年MM月DD日',
     /** バックエンドとの通信でエラーがあった場合に格納 */
     error: null as Error | null,
   }),
@@ -65,8 +64,8 @@ export const useMainStore = defineStore('mainStore', {
         const ansStart = dayjs(this.__memberStatus.details.researchStartDate);
         const ansEnd = dayjs(this.__memberStatus.details.researchEndDate);
         this.ansDateRange = `${ansStart.format(
-          this.showingDateFormat
-        )} ～ ${ansEnd.format(this.showingDateFormat)}`;
+          SHOWING_DATE_FORMAT
+        )} ～ ${ansEnd.format(SHOWING_DATE_FORMAT)}`;
         this.partyCount = this.__memberStatus.details.partyCount;
         this.bikou = this.__memberStatus.details.bikou;
       }


### PR DESCRIPTION
# 概要

TeamsのWebhook（Workflows）によるメッセージ通知システムを実装

実装に合わせて，Teams通知の「タイトル」と「メッセージ」のカスタマイズができる設定を`Config`に追加した



## Teamsの設定方法

基本的には[WorkflowsによるWebhook](https://support.microsoft.com/ja-jp/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498)の設定を行い，設定後に取得できるURLを取得すればよい

ただし，Workflows内の以下の設定を更新する必要がある

- 2項目目（Send each adaptive card）の「以前の手順から出力を選択」を**attachments**に変更する
> 似たような名称が初期設定に入っているが，それを削除して上記の名称の項目に変更する

- 2項目目（Send each adaptive card）の送信先が正しいことを確認し，「アダプティブカード」の項目が**content**になっていることを確認する

上記を設定しないと，APIを送信しても「attachmentsがありません」のようなエラーが発生する



## テストの実行方法

`packages\backend\src\source\teams.ts`内に実際にメッセージをTeamsに送信するテストが記載されているが，普段は`skip`で飛ばしているため，実行時は`skip`を外す必要がある

また，実行時にはWebhookのURLを環境変数から取得する仕様としているため，環境変数に下記の要領の設定を行っておく

|Key|Value|
|:---:|:---|
|`TEAMS_WEBHOOK_URL`|Webhook（Workflows）の設定で取得したURL|