### PR TITLE
調査終了後のUIを追加

### DIFF
--- a/packages/frontend/src/components/Calendar/FinishedDayBox.vue
+++ b/packages/frontend/src/components/Calendar/FinishedDayBox.vue
@@ -25,7 +25,7 @@ const classNames = () => {
     flat
     :size="$q.screen.gt.xs ? '1.5rem' : '1rem'"
     :class="classNames()"
-    style="pointer-events: none;"
+    style="pointer-events: none"
   >
     <div>
       <q-icon

--- a/packages/frontend/src/components/Calendar/FinishedDayBox.vue
+++ b/packages/frontend/src/components/Calendar/FinishedDayBox.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { PartyDate, RvDate } from '@research-vacant/common';
+import dayjs from 'dayjs';
+
+interface Prop {
+  date?: RvDate;
+  partyDates: PartyDate[];
+}
+const prop = defineProps<Prop>();
+
+const isPartyDate = prop.partyDates.some((d) => d.date === prop.date);
+
+const classNames = () => {
+  const returnClass = [];
+  returnClass.push(prop.date ? '' : 'disappear');
+  returnClass.push(isPartyDate ? 'selected' : 'disable');
+  return returnClass.join(' ');
+};
+</script>
+
+<template>
+  <q-btn
+    round
+    dense
+    flat
+    :size="$q.screen.gt.xs ? '1.5rem' : '1rem'"
+    :class="classNames()"
+    style="pointer-events: none;"
+  >
+    <div>
+      <q-icon
+        v-if="!isPartyDate"
+        name="pause"
+        color="grey-5"
+        :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
+        class="absolute-center disable"
+      />
+      <q-icon
+        v-else
+        name="check"
+        color="primary"
+        :size="$q.screen.gt.xs ? '3rem' : '1.5rem'"
+        class="absolute-center"
+      />
+      <div class="absolute-center text-bold day-text">
+        {{ dayjs(date).date() }}
+      </div>
+    </div>
+  </q-btn>
+</template>
+
+<style scoped lang="scss">
+.active-OK {
+  border: 3px solid $primary;
+}
+.active-Pending {
+  border: 3px solid $warning;
+}
+.active-NG {
+  border: 3px solid $negative;
+}
+.disable {
+  opacity: 0.5;
+}
+
+.day-text {
+  text-shadow: 1px 1px 0px #fff, -1px -1px 0px #fff, -1px 1px 0px #fff,
+    1px -1px 0px #fff, 1px 0px 0px #fff, -1px 0px 0px #fff, 0px 1px 0px #fff,
+    0px -1px 0px #fff;
+}
+
+.disappear {
+  visibility: hidden;
+}
+
+.selected {
+  margin: -3px;
+  border: 3px solid $primary;
+  background-color: rgba($color: $primary, $alpha: 0.1);
+}
+</style>

--- a/packages/frontend/src/components/CalendarView.vue
+++ b/packages/frontend/src/components/CalendarView.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
-import { AnswerSummary, CheckedOuterPlace } from '@research-vacant/common';
+import {
+  AnswerSummary,
+  CheckedOuterPlace,
+  PartyDate,
+} from '@research-vacant/common';
 import { useMainStore } from 'src/stores/main';
 import ApproveDayBox from './Calendar/ApproveDayBox.vue';
 import DayBox from './Calendar/DayBox.vue';
+import FinishedDayBox from './Calendar/FinishedDayBox.vue';
 import { isEnableDate } from './Calendar/script';
 
 interface Prop {
   summary: AnswerSummary;
   places?: CheckedOuterPlace[];
+  partyDates?: PartyDate[];
 }
 const prop = defineProps<Prop>();
 
@@ -66,6 +72,11 @@ function getSpecialHolidayName(idx: number, isWindowSize_gt_sm: boolean) {
           :ans-dates="summary.ansDates"
           :free-txts="summary.freeTxts"
           :places="places"
+        />
+        <FinishedDayBox
+          v-else-if="partyDates"
+          :date="mainStore.ansModel[n - 1]?.date"
+          :party-dates="partyDates"
         />
         <DayBox
           v-else

--- a/packages/frontend/src/components/LeftSideView.vue
+++ b/packages/frontend/src/components/LeftSideView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useQuasar } from 'quasar';
-import { PartyDate } from '@research-vacant/common';
+import { PartyDate, SHOWING_DATE_FORMAT } from '@research-vacant/common';
 import dayjs from 'dayjs';
 import { useMainStore } from 'src/stores/main';
 import { InfoDialogProp } from './Dialogs/iDialogProp';
@@ -60,7 +60,7 @@ function showInfoDialog() {
         :key="pDate.date"
         class="col justify-center row"
       >
-        <span>{{ dayjs(pDate.date).format(mainStore.showingDateFormat) }}</span>
+        <span>{{ dayjs(pDate.date).format(SHOWING_DATE_FORMAT) }}</span>
         <span class="q-mx-xs">＠</span>
         <a v-if="pDate.pos.placeURL" :href="pDate.pos.placeURL">
           {{ pDate.pos.placeName }}

--- a/packages/frontend/src/components/LeftSideView.vue
+++ b/packages/frontend/src/components/LeftSideView.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { useQuasar } from 'quasar';
+import { useMainStore } from 'src/stores/main';
+import { InfoDialogProp } from './Dialogs/iDialogProp';
+import InfoDialog from './Dialogs/InfoDialog.vue';
+import IndentLine from './utils/IndentLine.vue';
+
+interface Prop {
+  isManager?: boolean;
+  month: number;
+}
+const prop = defineProps<Prop>();
+
+const $q = useQuasar();
+const mainStore = useMainStore();
+
+/**
+ * 調査情報の詳細を表示（スマホ版）
+ */
+function showInfoDialog() {
+  $q.dialog({
+    component: InfoDialog,
+    componentProps: {
+      isManager: prop.isManager,
+    } as InfoDialogProp,
+  });
+}
+</script>
+
+<template>
+  <div class="col" style="min-width: 15rem">
+    <div class="row justify-between items-center">
+      <h1 class="text-bold">
+        {{ `${month}月の日程調整` }}
+      </h1>
+      <q-btn
+        flat
+        round
+        dense
+        icon="info"
+        color="info"
+        size="1.2rem"
+        class="lt-lg"
+        @click="showInfoDialog()"
+      />
+    </div>
+    <p>回答結果をもとに開催日を決定してください．</p>
+
+    <div class="gt-md">
+      <h2><u>開催日の詳細情報</u></h2>
+      <ul>
+        <li>
+          <q-input
+            v-if="isManager"
+            v-model="mainStore.partyCount"
+            dense
+            filled
+            label="開催回数"
+            class="q-my-sm"
+          />
+          <IndentLine v-else title="開催回数" max-width="10rem">
+            {{ mainStore.partyCount }}
+          </IndentLine>
+        </li>
+        <li>
+          <q-input
+            v-if="isManager"
+            v-model="mainStore.bikou"
+            dense
+            filled
+            type="textarea"
+            label="備考欄"
+            class="q-my-sm"
+          />
+          <IndentLine v-else title="備考欄" max-width="10rem">
+            <span style="white-space: pre-line">
+              {{ mainStore.bikou }}
+            </span>
+          </IndentLine>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/packages/frontend/src/components/LeftSideView.vue
+++ b/packages/frontend/src/components/LeftSideView.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { useQuasar } from 'quasar';
+import { PartyDate } from '@research-vacant/common';
+import dayjs from 'dayjs';
 import { useMainStore } from 'src/stores/main';
 import { InfoDialogProp } from './Dialogs/iDialogProp';
 import InfoDialog from './Dialogs/InfoDialog.vue';
@@ -8,6 +10,7 @@ import IndentLine from './utils/IndentLine.vue';
 interface Prop {
   isManager?: boolean;
   month: number;
+  partyDates?: PartyDate[];
 }
 const prop = defineProps<Prop>();
 
@@ -44,7 +47,29 @@ function showInfoDialog() {
         @click="showInfoDialog()"
       />
     </div>
-    <p>回答結果をもとに開催日を決定してください．</p>
+    <p v-if="!partyDates">回答結果をもとに開催日を決定してください．</p>
+    <div
+      v-else
+      style="border: 4px solid green"
+      class="column q-pa-md q-my-md text-bold text-h6 text-center"
+    >
+      <div class="col">決定した開催日</div>
+      <q-separator inset class="q-my-sm" />
+      <div
+        v-for="pDate in partyDates"
+        :key="pDate.date"
+        class="col justify-center row"
+      >
+        <span>{{ dayjs(pDate.date).format(mainStore.showingDateFormat) }}</span>
+        <span class="q-mx-xs">＠</span>
+        <a v-if="pDate.pos.placeURL" :href="pDate.pos.placeURL">
+          {{ pDate.pos.placeName }}
+        </a>
+        <span v-else>
+          {{ pDate.pos.placeName }}
+        </span>
+      </div>
+    </div>
 
     <div class="gt-md">
       <h2><u>開催日の詳細情報</u></h2>

--- a/packages/frontend/src/pages/IndexPage.vue
+++ b/packages/frontend/src/pages/IndexPage.vue
@@ -6,6 +6,7 @@ import ApprovePage from './Sub/ApprovePage.vue';
 import CalendarPage from './Sub/CalendarPage.vue';
 import ErrorPage from './Sub/ErrorPage.vue';
 import LoadingPage from './Sub/LoadingPage.vue';
+import FinishedPage from './Sub/FinishedPage.vue';
 
 const mainStore = useMainStore();
 const status: Ref<MemberStatus | undefined> = ref();
@@ -55,6 +56,10 @@ onMounted(async () => {
         :summary="status.summary"
         :places="status.places"
         :is-manager="status.isManager"
+      />
+      <FinishedPage
+        v-else-if="status.status === 'finished'"
+        
       />
       <CalendarPage
         v-else

--- a/packages/frontend/src/pages/IndexPage.vue
+++ b/packages/frontend/src/pages/IndexPage.vue
@@ -5,8 +5,8 @@ import { useMainStore } from 'src/stores/main';
 import ApprovePage from './Sub/ApprovePage.vue';
 import CalendarPage from './Sub/CalendarPage.vue';
 import ErrorPage from './Sub/ErrorPage.vue';
-import LoadingPage from './Sub/LoadingPage.vue';
 import FinishedPage from './Sub/FinishedPage.vue';
+import LoadingPage from './Sub/LoadingPage.vue';
 
 const mainStore = useMainStore();
 const status: Ref<MemberStatus | undefined> = ref();
@@ -59,7 +59,9 @@ onMounted(async () => {
       />
       <FinishedPage
         v-else-if="status.status === 'finished'"
-        
+        :summary="status.summary"
+        :party-dates="status.partyDates"
+        :is-manager="status.isManager"
       />
       <CalendarPage
         v-else

--- a/packages/frontend/src/pages/Sub/ApprovePage.vue
+++ b/packages/frontend/src/pages/Sub/ApprovePage.vue
@@ -12,10 +12,8 @@ import CheckDialog from 'src/components/Dialogs/CheckDialog.vue';
 import {
   ApproveSendingDialogProp,
   CheckDialogProp,
-  InfoDialogProp,
 } from 'src/components/Dialogs/iDialogProp';
-import InfoDialog from 'src/components/Dialogs/InfoDialog.vue';
-import IndentLine from 'src/components/utils/IndentLine.vue';
+import LeftSideView from 'src/components/LeftSideView.vue';
 import { useMainStore } from 'src/stores/main';
 
 interface Prop {
@@ -38,18 +36,6 @@ function submitAns() {
       places: prop.places,
       summary: prop.summary,
     } as ApproveSendingDialogProp,
-  });
-}
-
-/**
- * 調査情報の詳細を表示（スマホ版）
- */
-function showInfoDialog() {
-  $q.dialog({
-    component: InfoDialog,
-    componentProps: {
-      isManager: prop.isManager,
-    } as InfoDialogProp,
   });
 }
 
@@ -80,57 +66,10 @@ function resetAllAns() {
       <div class="col"></div>
       <!-- main display -->
       <div class="col row">
-        <div class="col" style="min-width: 15rem">
-          <div class="row justify-between items-center">
-            <h1 class="text-bold">
-              {{ `${dayjs(summary.ansDates[0].date).month() + 1}月の日程調整` }}
-            </h1>
-            <q-btn
-              flat
-              round
-              dense
-              icon="info"
-              color="info"
-              size="1.2rem"
-              class="lt-lg"
-              @click="showInfoDialog()"
-            />
-          </div>
-          <p>回答結果をもとに開催日を決定してください．</p>
-
-          <div class="gt-md">
-            <h2><u>開催日の詳細情報</u></h2>
-            <ul>
-              <li>
-                <q-input
-                  v-if="isManager"
-                  v-model="mainStore.partyCount"
-                  dense
-                  filled
-                  label="開催回数"
-                  class="q-my-sm"
-                />
-                <IndentLine v-else title="開催回数" max-width="10rem">
-                  {{ mainStore.partyCount }}
-                </IndentLine>
-              </li>
-              <li>
-                <q-input
-                  v-if="isManager"
-                  v-model="mainStore.bikou"
-                  dense
-                  filled
-                  type="textarea"
-                  label="備考欄"
-                  class="q-my-sm"
-                />
-                <IndentLine v-else title="備考欄" max-width="10rem">
-                  {{ mainStore.bikou }}
-                </IndentLine>
-              </li>
-            </ul>
-          </div>
-        </div>
+        <LeftSideView
+          :is-manager="isManager"
+          :month="dayjs(summary.ansDates[0].date).month() + 1"
+        />
         <div style="max-width: min(90vw, 50rem); margin: 0 auto">
           <CalendarView :summary="summary" :places="places" />
         </div>

--- a/packages/frontend/src/pages/Sub/CalendarPage.vue
+++ b/packages/frontend/src/pages/Sub/CalendarPage.vue
@@ -5,12 +5,8 @@ import dayjs from 'dayjs';
 import CalendarView from 'src/components/CalendarView.vue';
 import AnsSendingDialog from 'src/components/Dialogs/AnsSendingDialog.vue';
 import CheckDialog from 'src/components/Dialogs/CheckDialog.vue';
-import {
-  CheckDialogProp,
-  InfoDialogProp,
-} from 'src/components/Dialogs/iDialogProp';
-import InfoDialog from 'src/components/Dialogs/InfoDialog.vue';
-import IndentLine from 'src/components/utils/IndentLine.vue';
+import { CheckDialogProp } from 'src/components/Dialogs/iDialogProp';
+import LeftSideView from 'src/components/LeftSideView.vue';
 import { useMainStore } from 'src/stores/main';
 
 interface Prop {
@@ -36,18 +32,6 @@ function submitAns() {
  */
 function changeViewer() {
   mainStore.isShowApproverView = true;
-}
-
-/**
- * 調査情報の詳細を表示（スマホ版）
- */
-function showInfoDialog() {
-  $q.dialog({
-    component: InfoDialog,
-    componentProps: {
-      isManager: prop.isManager,
-    } as InfoDialogProp,
-  });
 }
 
 /**
@@ -77,64 +61,10 @@ function resetAllAns() {
       <div class="col"></div>
       <!-- main display -->
       <div class="col row">
-        <div class="col" style="min-width: 15rem">
-          <div class="row justify-between items-center">
-            <h1 class="text-bold">
-              {{ `${dayjs(summary.ansDates[0].date).month() + 1}月の日程調整` }}
-            </h1>
-            <q-btn
-              flat
-              round
-              dense
-              icon="info"
-              color="info"
-              size="1.2rem"
-              class="lt-lg"
-              @click="showInfoDialog()"
-            />
-          </div>
-          <p>空き日程をカレンダーよりご回答ください．</p>
-
-          <div class="gt-md">
-            <h2><u>調整＆開催日の詳細情報</u></h2>
-            <ul>
-              <li>
-                <IndentLine title="回答期間" max-width="10rem">
-                  {{ mainStore.ansDateRange }}
-                </IndentLine>
-              </li>
-              <li>
-                <q-input
-                  v-if="isManager"
-                  v-model="mainStore.partyCount"
-                  dense
-                  filled
-                  label="開催回数"
-                  class="q-my-sm"
-                />
-                <IndentLine v-else title="開催回数" max-width="10rem">
-                  {{ mainStore.partyCount }}
-                </IndentLine>
-              </li>
-              <li>
-                <q-input
-                  v-if="isManager"
-                  v-model="mainStore.bikou"
-                  dense
-                  filled
-                  type="textarea"
-                  label="備考欄"
-                  class="q-my-sm"
-                />
-                <IndentLine v-else title="備考欄" max-width="10rem">
-                  <span style="white-space: pre-line">
-                    {{ mainStore.bikou }}
-                  </span>
-                </IndentLine>
-              </li>
-            </ul>
-          </div>
-        </div>
+        <LeftSideView
+          :is-manager="isManager"
+          :month="dayjs(summary.ansDates[0].date).month() + 1"
+        />
         <div style="max-width: min(90vw, 50rem); margin: 0 auto">
           <CalendarView :summary="summary" />
         </div>

--- a/packages/frontend/src/pages/Sub/FinishedPage.vue
+++ b/packages/frontend/src/pages/Sub/FinishedPage.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { AnswerSummary, PartyDate } from '@research-vacant/common';
+import dayjs from 'dayjs';
+import { useMainStore } from 'src/stores/main';
+
+interface Prop {
+  summary: AnswerSummary;
+  partyDates: PartyDate[];
+  isManager: boolean;
+}
+const prop = defineProps<Prop>();
+
+const mainStore = useMainStore();
+</script>
+
+<template>
+  <q-card flat class="col column">
+    <q-card-section class="col column items-center">
+      <div class="col"></div>
+      <!-- main display -->
+      <div class="col row">
+        <div class="col" style="min-width: 15rem">
+          <div class="row justify-between items-center">
+            <h1 class="text-bold">
+              {{ `${dayjs(summary.ansDates[0].date).month() + 1}月の日程調整` }}
+            </h1>
+            <q-btn
+              flat
+              round
+              dense
+              icon="info"
+              color="info"
+              size="1.2rem"
+              class="lt-lg"
+              @click="showInfoDialog()"
+            />
+          </div>
+          <p>回答結果をもとに開催日を決定してください．</p>
+
+          <div class="gt-md">
+            <h2><u>開催日の詳細情報</u></h2>
+            <ul>
+              <li>
+                <q-input
+                  v-if="isManager"
+                  v-model="mainStore.partyCount"
+                  dense
+                  filled
+                  label="開催回数"
+                  class="q-my-sm"
+                />
+                <IndentLine v-else title="開催回数" max-width="10rem">
+                  {{ mainStore.partyCount }}
+                </IndentLine>
+              </li>
+              <li>
+                <q-input
+                  v-if="isManager"
+                  v-model="mainStore.bikou"
+                  dense
+                  filled
+                  type="textarea"
+                  label="備考欄"
+                  class="q-my-sm"
+                />
+                <IndentLine v-else title="備考欄" max-width="10rem">
+                  {{ mainStore.bikou }}
+                </IndentLine>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div style="max-width: min(90vw, 50rem); margin: 0 auto">
+          <CalendarView :summary="summary" :places="places" />
+        </div>
+      </div>
+
+      <!-- free text -->
+      <div class="col fit" style="max-width: min(95vw, 80rem)">
+        <h2>フリーメッセージ</h2>
+        <q-input v-model="mainStore.freeTxt" filled style="font-size: 1rem" />
+      </div>
+    </q-card-section>
+
+    <q-separator />
+
+    <q-card-actions align="right">
+      <div class="row q-gutter-x-lg q-py-sm">
+        <q-btn outline size="1rem" :disable="isManager" @click="resetAllAns()">
+          入力内容をリセット
+        </q-btn>
+        <q-btn
+          fill
+          color="primary"
+          size="1rem"
+          :disable="isManager"
+          @click="submitAns()"
+        >
+          開催日を確認
+        </q-btn>
+      </div>
+    </q-card-actions>
+  </q-card>
+</template>

--- a/packages/frontend/src/pages/Sub/FinishedPage.vue
+++ b/packages/frontend/src/pages/Sub/FinishedPage.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { AnswerSummary } from '@research-vacant/common';
+import { AnswerSummary, PartyDate } from '@research-vacant/common';
 import dayjs from 'dayjs';
 import CalendarView from 'src/components/CalendarView.vue';
 import LeftSideView from 'src/components/LeftSideView.vue';
 
 interface Prop {
   summary: AnswerSummary;
+  partyDates: PartyDate[];
   isManager: boolean;
 }
 defineProps<Prop>();
@@ -18,38 +19,13 @@ defineProps<Prop>();
       <!-- main display -->
       <div class="col row">
         <LeftSideView
-          :is-manager="isManager"
           :month="dayjs(summary.ansDates[0].date).month() + 1"
+          :party-dates="partyDates"
         />
         <div style="max-width: min(90vw, 50rem); margin: 0 auto">
-          <CalendarView :summary="summary" />
+          <CalendarView :summary="summary" :party-dates="partyDates" />
         </div>
       </div>
-
-      <!-- free text -->
-      <!-- <div class="col fit" style="max-width: min(95vw, 80rem)">
-        <h2>フリーメッセージ</h2>
-        <q-input v-model="mainStore.freeTxt" filled style="font-size: 1rem" />
-      </div> -->
     </q-card-section>
-
-    <q-separator />
-
-    <q-card-actions align="right">
-      <div class="row q-gutter-x-lg q-py-sm">
-        <!-- <q-btn outline size="1rem" :disable="isManager" @click="resetAllAns()">
-          入力内容をリセット
-        </q-btn>
-        <q-btn
-          fill
-          color="primary"
-          size="1rem"
-          :disable="isManager"
-          @click="submitAns()"
-        >
-          開催日を確認
-        </q-btn> -->
-      </div>
-    </q-card-actions>
   </q-card>
 </template>

--- a/packages/frontend/src/pages/Sub/FinishedPage.vue
+++ b/packages/frontend/src/pages/Sub/FinishedPage.vue
@@ -1,16 +1,14 @@
 <script setup lang="ts">
-import { AnswerSummary, PartyDate } from '@research-vacant/common';
+import { AnswerSummary } from '@research-vacant/common';
 import dayjs from 'dayjs';
-import { useMainStore } from 'src/stores/main';
+import CalendarView from 'src/components/CalendarView.vue';
+import LeftSideView from 'src/components/LeftSideView.vue';
 
 interface Prop {
   summary: AnswerSummary;
-  partyDates: PartyDate[];
   isManager: boolean;
 }
-const prop = defineProps<Prop>();
-
-const mainStore = useMainStore();
+defineProps<Prop>();
 </script>
 
 <template>
@@ -19,74 +17,27 @@ const mainStore = useMainStore();
       <div class="col"></div>
       <!-- main display -->
       <div class="col row">
-        <div class="col" style="min-width: 15rem">
-          <div class="row justify-between items-center">
-            <h1 class="text-bold">
-              {{ `${dayjs(summary.ansDates[0].date).month() + 1}月の日程調整` }}
-            </h1>
-            <q-btn
-              flat
-              round
-              dense
-              icon="info"
-              color="info"
-              size="1.2rem"
-              class="lt-lg"
-              @click="showInfoDialog()"
-            />
-          </div>
-          <p>回答結果をもとに開催日を決定してください．</p>
-
-          <div class="gt-md">
-            <h2><u>開催日の詳細情報</u></h2>
-            <ul>
-              <li>
-                <q-input
-                  v-if="isManager"
-                  v-model="mainStore.partyCount"
-                  dense
-                  filled
-                  label="開催回数"
-                  class="q-my-sm"
-                />
-                <IndentLine v-else title="開催回数" max-width="10rem">
-                  {{ mainStore.partyCount }}
-                </IndentLine>
-              </li>
-              <li>
-                <q-input
-                  v-if="isManager"
-                  v-model="mainStore.bikou"
-                  dense
-                  filled
-                  type="textarea"
-                  label="備考欄"
-                  class="q-my-sm"
-                />
-                <IndentLine v-else title="備考欄" max-width="10rem">
-                  {{ mainStore.bikou }}
-                </IndentLine>
-              </li>
-            </ul>
-          </div>
-        </div>
+        <LeftSideView
+          :is-manager="isManager"
+          :month="dayjs(summary.ansDates[0].date).month() + 1"
+        />
         <div style="max-width: min(90vw, 50rem); margin: 0 auto">
-          <CalendarView :summary="summary" :places="places" />
+          <CalendarView :summary="summary" />
         </div>
       </div>
 
       <!-- free text -->
-      <div class="col fit" style="max-width: min(95vw, 80rem)">
+      <!-- <div class="col fit" style="max-width: min(95vw, 80rem)">
         <h2>フリーメッセージ</h2>
         <q-input v-model="mainStore.freeTxt" filled style="font-size: 1rem" />
-      </div>
+      </div> -->
     </q-card-section>
 
     <q-separator />
 
     <q-card-actions align="right">
       <div class="row q-gutter-x-lg q-py-sm">
-        <q-btn outline size="1rem" :disable="isManager" @click="resetAllAns()">
+        <!-- <q-btn outline size="1rem" :disable="isManager" @click="resetAllAns()">
           入力内容をリセット
         </q-btn>
         <q-btn
@@ -97,7 +48,7 @@ const mainStore = useMainStore();
           @click="submitAns()"
         >
           開催日を確認
-        </q-btn>
+        </q-btn> -->
       </div>
     </q-card-actions>
   </q-card>

--- a/teamsTest.py
+++ b/teamsTest.py
@@ -1,0 +1,39 @@
+import requests
+import json
+
+# TeamsのWebhook URL
+webhook_url = 'https://prod-30.japaneast.logic.azure.com/workflows/724376f5d28b41cf88315a1e877676d4/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=hmaHUkMfgG1I7EA5j2Ti9G1ZfJxhQUBR8LPAbHJeAjw'
+
+# 送信するメッセージ
+message = {
+  "attachments": [
+    {
+      "contentType": "application/vnd.microsoft.card.adaptive",
+      "content": {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.2",
+        "body": [
+          {
+            "type": "TextBlock",
+            "text": "## Workflow経由のTeamsへの通知テストです。\n\n* 通知の詳細1です。\n* 通知の詳細2です。",
+            "wrap": True,
+            "markdown": True
+          }
+        ]
+      }
+    }
+  ]
+}
+# POSTリクエストを送信
+response = requests.post(
+    url=webhook_url,
+    data=json.dumps(message),
+    headers={'Content-Type': 'application/json'}
+)
+
+# レスポンスを確認
+if response.status_code == 200 or response.status_code == 202:
+    print("メッセージが送信されました")
+else:
+    print(f"エラーが発生しました: {response.status_code}, {response.text}")


### PR DESCRIPTION
# 概要

日程調査終了後にアクセスがあった際に表示する画面を追加

日程調査が終了しているため，決定した日付を提示する画面とした


## 変更箇所

- 終了後の画面`FinishedPage.vue`を実装
- 画面左側の概要や表示月の情報を提示する部分を共通化