### PR TITLE
新メンバーに案内メールを送る機能を追加

### DIFF
--- a/packages/backend/src/core/research.ts
+++ b/packages/backend/src/core/research.ts
@@ -3,10 +3,10 @@
  */
 import dayjs from 'dayjs';
 import { updateSession } from 'backend/source/spreadsheet/session';
-import { sessionChecker } from './research/checker';
+import { newMemberChecker, sessionChecker } from './research/checker';
 import { sendJudgeCandidate } from './research/decideHoldingDate';
 import { sendRemind } from './research/remindResearch';
-import { startSession } from './research/startResearch';
+import { sendAnnounce, startSession } from './research/startResearch';
 
 /**
  * この関数を毎日実行し，ステータスに応じた処理を実行する
@@ -14,6 +14,7 @@ import { startSession } from './research/startResearch';
 export function researchManager() {
   // セッション一覧・設定シートを確認し，開催中の調査（リマインドの送付，終了案内の送付等）や開始すべき調査について確認する
   const sessions = sessionChecker();
+  const newMembers = newMemberChecker();
 
   sessions.forEach((session) => {
     // 新規でセッションを開始（'ready' -> 'opening'）
@@ -48,12 +49,17 @@ export function researchManager() {
       // 現状ではすべてのセッションはバックログとして残しておくことにしているため，コメントアウト
       // cleanUpBackData(session.id)
     }
+
+    // 新規メンバーに案内を送付
+    if (newMembers.length > 0 && session.status === 'opening') {
+      sendAnnounce(session.id, newMembers);
+    }
   });
 }
 
 /** In Source Testing */
 if (import.meta.vitest) {
-  const { test, expect } = import.meta.vitest;
+  const { describe, test, expect } = import.meta.vitest;
   test('dayjs', () => {
     const today = dayjs('2024-01-03');
     expect(today.diff('2024-01-05', 'day')).toBe(-2);
@@ -61,5 +67,43 @@ if (import.meta.vitest) {
     expect(today.isAfter('2024-01-01', 'day')).toBe(true);
   });
 
-  // TODO: テストを作成
+  describe('researchManager', async () => {
+    // mocks
+    const { SpreadsheetApp, Utilities, LockService, Logger } = await import(
+      '@research-vacant/mock'
+    );
+    global.SpreadsheetApp = new SpreadsheetApp();
+    global.Utilities = new Utilities();
+    global.LockService = new LockService();
+    global.Logger = new Logger();
+
+    // initialize
+    const { migrateEnv } = await import('./migrate');
+    migrateEnv();
+
+    // sample member
+    const { imitateRegistMember } = await import(
+      'backend/source/spreadsheet/members'
+    );
+    imitateRegistMember({
+      id: '',
+      firstName: 'サンプル',
+      lastName: '太郎',
+      mailAddress: 'sample@email.com',
+      roles: '',
+    });
+    imitateRegistMember({
+      id: '00000000-0000-0000-0000-000000000000',
+      firstName: 'サンプル',
+      lastName: '登録済み',
+      mailAddress: 'sample@email.com',
+      roles: '',
+    });
+
+    test('newMemberChecker', () => {
+      // get members
+      const members = newMemberChecker();
+      expect(members.length).toBe(1);
+    });
+  });
 }

--- a/packages/backend/src/core/research/checker.ts
+++ b/packages/backend/src/core/research/checker.ts
@@ -1,11 +1,17 @@
-import { Config, Member, RvDate, Session, values } from '@research-vacant/common';
+import {
+  Config,
+  Member,
+  RvDate,
+  Session,
+  values,
+} from '@research-vacant/common';
 import dayjs from 'dayjs';
 import { getConfig } from 'backend/source/spreadsheet/config';
+import { getMembers } from 'backend/source/spreadsheet/members';
 import {
   getSessions,
   publishSession,
 } from 'backend/source/spreadsheet/session';
-import { getMembers } from 'backend/source/spreadsheet/members';
 
 /**
  * セッションの一覧を取得し，本日の日付に対して必要なセッションの発行を行う

--- a/packages/backend/src/core/research/checker.ts
+++ b/packages/backend/src/core/research/checker.ts
@@ -1,10 +1,11 @@
-import { Config, RvDate, Session, values } from '@research-vacant/common';
+import { Config, Member, RvDate, Session, values } from '@research-vacant/common';
 import dayjs from 'dayjs';
 import { getConfig } from 'backend/source/spreadsheet/config';
 import {
   getSessions,
   publishSession,
 } from 'backend/source/spreadsheet/session';
+import { getMembers } from 'backend/source/spreadsheet/members';
 
 /**
  * セッションの一覧を取得し，本日の日付に対して必要なセッションの発行を行う
@@ -32,6 +33,13 @@ export function sessionChecker(): Session[] {
 
   // publishしたセッションを追加済みの最新のリストを返す
   return values(getSessions());
+}
+
+/**
+ * 新規追加されたメンバ―の一覧を取得する
+ */
+export function newMemberChecker(): Member[] {
+  return values(getMembers(false, true));
 }
 
 /**

--- a/packages/backend/src/core/research/startResearch.ts
+++ b/packages/backend/src/core/research/startResearch.ts
@@ -1,4 +1,4 @@
-import { SessionID, values } from '@research-vacant/common';
+import { Member, SessionID, values } from '@research-vacant/common';
 import { sendAnnounceMail } from 'backend/source/mail';
 import { initAnsRecordSheet } from 'backend/source/spreadsheet/answers';
 import { getMembers } from 'backend/source/spreadsheet/members';
@@ -11,13 +11,20 @@ export function startSession(sessionId: SessionID) {
   initAnsRecordSheet(sessionId);
 
   // 案内メールの送付
-  sendAnnounce(sessionId);
+  sendAnnounce4AllMembers(sessionId);
 }
 
 /**
  * 部員全員に案内メールを送信する
  */
-function sendAnnounce(sessionId: SessionID) {
+function sendAnnounce4AllMembers(sessionId: SessionID) {
   const members = values(getMembers());
+  sendAnnounce(sessionId, members);
+}
+
+/**
+ * 指定したメンバーにのみ案内メールを送信する
+ */
+export function sendAnnounce(sessionId: SessionID, members: Member[]) {
   members.forEach((m) => sendAnnounceMail(sessionId, m));
 }

--- a/packages/backend/src/source/spreadsheet/answers.ts
+++ b/packages/backend/src/source/spreadsheet/answers.ts
@@ -13,7 +13,7 @@ import {
   values,
 } from '@research-vacant/common';
 import dayjs from 'dayjs';
-import { getSheet, warpLock } from './common';
+import { getSheet, wrapLock } from './common';
 
 const ansHeader: Record<keyof Answer, string> = {
   userId: 'メンバーID',
@@ -30,7 +30,7 @@ export function initAnsRecordSheet(
   sessionId: SessionID,
   clearAllData: boolean = false
 ) {
-  warpLock(() => __initAnsRecordSheet(sessionId, clearAllData));
+  wrapLock(() => __initAnsRecordSheet(sessionId, clearAllData));
 }
 
 function __initAnsRecordSheet(
@@ -221,7 +221,7 @@ export function registAnswer(sessionId: SessionID, record: Answer) {
   answers[record.userId] = record;
 
   // write for db
-  warpLock(() => writeAnswers(sessionId, answers));
+  wrapLock(() => writeAnswers(sessionId, answers));
 }
 
 /** In Source Testing */

--- a/packages/backend/src/source/spreadsheet/common.ts
+++ b/packages/backend/src/source/spreadsheet/common.ts
@@ -21,7 +21,7 @@ export function getSheet(sheetName: string, createNewSheet: boolean = false) {
 /**
  * シートの更新処理に対してロック管理を付与する
  */
-export function warpLock<T>(func: () => T, timeout: number = 10 * 1000) {
+export function wrapLock<T>(func: () => T, timeout: number = 10 * 1000) {
   const lock = LockService.getScriptLock();
   if (lock.tryLock(timeout)) {
     // execute update process

--- a/packages/backend/src/source/spreadsheet/common.ts
+++ b/packages/backend/src/source/spreadsheet/common.ts
@@ -21,14 +21,17 @@ export function getSheet(sheetName: string, createNewSheet: boolean = false) {
 /**
  * シートの更新処理に対してロック管理を付与する
  */
-export function warpLock(func: () => void, timeout: number = 10 * 1000) {
+export function warpLock<T>(func: () => T, timeout: number = 10 * 1000) {
   const lock = LockService.getScriptLock();
   if (lock.tryLock(timeout)) {
     // execute update process
-    func();
+    const res = func();
 
     // release lock
     lock.releaseLock();
+
+    // return function result
+    return res;
   } else {
     throw new Error('CAN NOT UPDATE SHEET (Failed to get LOCK)');
   }

--- a/packages/backend/src/source/spreadsheet/config.ts
+++ b/packages/backend/src/source/spreadsheet/config.ts
@@ -5,7 +5,7 @@ import {
   keys,
   researchFrequencyEnum,
 } from '@research-vacant/common';
-import { getSheet, warpLock } from './common';
+import { getSheet, wrapLock } from './common';
 
 const CONFIG_SHEET_NAME = '設定';
 
@@ -39,7 +39,7 @@ let configCache: Config | undefined;
  * 設定シートの初期化
  */
 export function initConfigSheet(clearAllData: boolean = false) {
-  warpLock(() => __initConfigSheet(clearAllData));
+  wrapLock(() => __initConfigSheet(clearAllData));
 }
 
 function __initConfigSheet(clearAllData: boolean = false) {

--- a/packages/backend/src/source/spreadsheet/decideRecord.ts
+++ b/packages/backend/src/source/spreadsheet/decideRecord.ts
@@ -10,7 +10,7 @@ import {
   toEntries,
   values,
 } from '@research-vacant/common';
-import { getSheet, warpLock } from './common';
+import { getSheet, wrapLock } from './common';
 
 const RECORD_SHEET_NAME = '決定済み開催日一覧';
 let cachedRecords: Record<SessionID, DecidedRecord> | undefined;
@@ -25,7 +25,7 @@ const header: Record<keyof DecidedRecord, string> = {
  * セッションシートの初期化に用いる
  */
 export function initRecordsSheet(clearAllData: boolean = false) {
-  warpLock(() => __initRecordsSheet(clearAllData));
+  wrapLock(() => __initRecordsSheet(clearAllData));
 }
 
 function __initRecordsSheet(clearAllData: boolean = false) {
@@ -127,5 +127,5 @@ function writeRecords(records: Record<SessionID, DecidedRecord>) {
 export function registPartyDate(sessionId: SessionID, infos: PartyInfo[]) {
   const tmpRecords = getPartys();
   tmpRecords[sessionId] = { sessionId, infos };
-  warpLock(() => writeRecords(tmpRecords));
+  wrapLock(() => writeRecords(tmpRecords));
 }

--- a/packages/backend/src/source/spreadsheet/members.ts
+++ b/packages/backend/src/source/spreadsheet/members.ts
@@ -7,7 +7,7 @@ import {
   toEntries,
   values,
 } from '@research-vacant/common';
-import { getSheet, warpLock } from './common';
+import { getSheet, wrapLock } from './common';
 import { getConfig } from './config';
 
 const MEMBERS_SHEET_NAME = 'メンバー一覧';
@@ -33,7 +33,7 @@ function genMemberID() {
  * メンバー一覧シートの初期化に用いる
  */
 export function initMemberSheet(clearAllData: boolean = false) {
-  warpLock(() => __initMemberSheet(clearAllData));
+  wrapLock(() => __initMemberSheet(clearAllData));
 }
 
 function __initMemberSheet(clearAllData: boolean = false) {
@@ -78,7 +78,7 @@ export function getMembers(
   loadForce: boolean = false,
   onlyNewMember: boolean = false
 ) {
-  return warpLock(() => __getMembers(loadForce, onlyNewMember));
+  return wrapLock(() => __getMembers(loadForce, onlyNewMember));
 }
 
 export function __getMembers(loadForce: boolean, onlyNewMember: boolean) {

--- a/packages/backend/src/source/spreadsheet/members.ts
+++ b/packages/backend/src/source/spreadsheet/members.ts
@@ -81,7 +81,12 @@ export function getMembers(
   return wrapLock(() => __getMembers(loadForce, onlyNewMember));
 }
 
-export function __getMembers(loadForce: boolean, onlyNewMember: boolean) {
+export function __getMembers(
+  loadForce: boolean,
+  onlyNewMember: boolean
+): Record<MemberID, Member> {
+  const newMemberIds: MemberID[] = [];
+
   if (!cachedMembers || loadForce) {
     const sheet = getSheet(MEMBERS_SHEET_NAME);
 
@@ -105,6 +110,7 @@ export function __getMembers(loadForce: boolean, onlyNewMember: boolean) {
                 const memberId = line[idx] === '' ? genMemberID() : line[idx];
                 // MemberIDがないときはDBに書き込む
                 if (line[idx] === '') {
+                  newMemberIds.push(memberId);
                   sheet
                     .getRange(rowIdx + 2, memberidIdx + 1)
                     .setValue(memberId);
@@ -136,6 +142,12 @@ export function __getMembers(loadForce: boolean, onlyNewMember: boolean) {
         mustAttend: !!cachedMembers[keys(cachedMembers)[0]].roles?.mustAttend,
       };
     }
+  }
+
+  if (onlyNewMember) {
+    return fromEntries(
+      toEntries(cachedMembers).filter(([id, m]) => newMemberIds.includes(id))
+    );
   }
 
   return cachedMembers;

--- a/packages/backend/src/source/spreadsheet/members.ts
+++ b/packages/backend/src/source/spreadsheet/members.ts
@@ -74,7 +74,14 @@ function roleParser(roleName: string[]): Role {
 /**
  * メンバー一覧を取得
  */
-export function getMembers(loadForce: boolean = false) {
+export function getMembers(
+  loadForce: boolean = false,
+  onlyNewMember: boolean = false
+) {
+  return warpLock(() => __getMembers(loadForce, onlyNewMember));
+}
+
+export function __getMembers(loadForce: boolean, onlyNewMember: boolean) {
   if (!cachedMembers || loadForce) {
     const sheet = getSheet(MEMBERS_SHEET_NAME);
 

--- a/packages/backend/src/source/spreadsheet/session.ts
+++ b/packages/backend/src/source/spreadsheet/session.ts
@@ -8,7 +8,7 @@ import {
   toEntries,
   values,
 } from '@research-vacant/common';
-import { getSheet, warpLock } from './common';
+import { getSheet, wrapLock } from './common';
 import { getConfig } from './config';
 
 const SESSION_SHEET_NAME = 'セッション一覧';
@@ -68,7 +68,7 @@ function writeSessions(sessions?: Record<SessionID, Session>) {
  * セッションシートの初期化に用いる
  */
 export function initSessionSheet(clearAllData: boolean = false) {
-  warpLock(() => __initSessionSheet(clearAllData));
+  wrapLock(() => __initSessionSheet(clearAllData));
 }
 
 function __initSessionSheet(clearAllData: boolean = false) {
@@ -143,7 +143,7 @@ export function publishSession(
   // 書き込み
   const sessions = getSessions();
   sessions[writeSession.id] = writeSession;
-  warpLock(() => writeSessions(sessions));
+  wrapLock(() => writeSessions(sessions));
 
   return writeSession;
 }
@@ -174,7 +174,7 @@ export function updateSession(
   if (bikou) {
     sessions[sessionId].bikou = bikou;
   }
-  warpLock(() => writeSessions(sessions));
+  wrapLock(() => writeSessions(sessions));
 }
 
 /**
@@ -186,5 +186,5 @@ export function deleteSession(sessionId: SessionID) {
   delete sessions[sessionId];
 
   // delete Session
-  warpLock(() => writeSessions(sessions));
+  wrapLock(() => writeSessions(sessions));
 }


### PR DESCRIPTION
# 概要

開始済みの調査があるときに新メンバーが追加された際，当該メンバーに対しても調査がなされるように案内メールを送付する機能を追加

Fixed #20 


## 変更内容
- 新メンバーの列挙関数`newMemberChecker()`を追加（当該実行時における新メンバー）
- MemberID書き込み時の処理にLockがかかっていない不具合の修正